### PR TITLE
Avoid installing win32-security gem on non-Windows platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :development do
   gem "active_record_doctor"
   gem "faker"
   gem "web-console", ">= 3.3.0"
-  gem "win32-security"
+  gem "win32-security", platforms: [:mingw, :x64_mingw, :mswin]
 end
 
 group :production do


### PR DESCRIPTION
This PR ensures that local development of the project can occur on non-Windows platforms