### PR TITLE
Add warning about changing import code on revisions

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -36,6 +36,7 @@
 //= require navigation
 //= require reveal-by-checkbox
 //= require reveal-by-select
+//= require reveal-on-difference
 //= require timeago
 //= require toggle-content
 //= require wiki/search

--- a/app/assets/javascripts/reveal-on-difference.js
+++ b/app/assets/javascripts/reveal-on-difference.js
@@ -1,0 +1,16 @@
+document.addEventListener("turbolinks:load", function() {
+    const elements = document.querySelectorAll("[data-action='reveal-on-difference']")
+
+    elements.forEach((element) => element.removeEventListener("change", toggleRevealOnDifference))
+    elements.forEach((element) => element.addEventListener("change", toggleRevealOnDifference))
+})
+
+function toggleRevealOnDifference(event) {
+    const value = this.value
+    const original = this.dataset.original
+    const different = value !== original
+
+    const elements = document.querySelectorAll("[data-role='reveal-on-difference']")
+
+    elements.forEach(element => element.style.display = different ? "block" : "none")
+}

--- a/app/assets/javascripts/reveal-on-difference.js
+++ b/app/assets/javascripts/reveal-on-difference.js
@@ -8,7 +8,7 @@ document.addEventListener("turbolinks:load", function() {
 function toggleRevealOnDifference(event) {
     const value = this.value
     const original = this.dataset.original
-    const different = value !== original
+    const different = value !== original && original !== undefined
 
     const elements = document.querySelectorAll("[data-role='reveal-on-difference']")
 

--- a/app/assets/javascripts/reveal-on-difference.js
+++ b/app/assets/javascripts/reveal-on-difference.js
@@ -1,8 +1,8 @@
 document.addEventListener("turbolinks:load", function() {
     const elements = document.querySelectorAll("[data-action='reveal-on-difference']")
 
-    elements.forEach((element) => element.removeEventListener("change", toggleRevealOnDifference))
-    elements.forEach((element) => element.addEventListener("change", toggleRevealOnDifference))
+    elements.forEach((element) => element.removeEventListener("input", toggleRevealOnDifference))
+    elements.forEach((element) => element.addEventListener("input", toggleRevealOnDifference))
 })
 
 function toggleRevealOnDifference(event) {

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -7,8 +7,13 @@
     </div>
 
     <div class="form-group">
-      <%= form.text_field :code, class: "form-input form-input--large", placeholder: t("posts.form.code"), autocomplete: "off" %>
+      <%= form.text_field :code, class: "form-input form-input--large", placeholder: t("posts.form.code"), data: { action: "reveal-on-difference", original: @post.code }, autocomplete: "off" %>
     </div>
+  </div>
+
+  <div class="well well--dark block warning mt-1/4 mb-1/4 pt-1/8 pb-1/8" data-role="reveal-on-difference" style="display: none">
+    <p class="mb-0"><mark>Heads up!</mark></p>
+    <p class="mt-0"><small>If you aren't trying to have an import code for each version, you probably want to update your existing import code instead of making a new one. If you're not sure how to do that, read this <a href="https://workshop.codes/wiki/articles/uploading+new+content+to+existing+import+code" target="_blank"><mark>Wiki article</mark></a>.</small></p>
   </div>
 
   <div class="form-group-uneven mt-1/2" data-reveal-by-select-parent>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,9 +12,9 @@
   </div>
 
   <div class="well well--dark block warning mt-1/4 mb-1/4 pt-1/8 pb-1/8" data-role="reveal-on-difference" style="display: none">
-    <p class="mb-0"><mark>Heads up!</mark></p>
-    <p class="mt-0"><small>If you aren't trying to have an import code for each version, you probably want to update your existing import code instead of making a new one. If you're not sure how to do that, read this <a href="https://workshop.codes/wiki/articles/uploading+new+content+to+existing+import+code" target="_blank"><mark>Wiki article</mark></a>.</small></p>
-    <p class="mt-0"><small>In case you forgot, your original import code is <code><%= @post.code %></code></small></p>
+    <p class="mb-0"><mark><%= t("posts.form.code_change.attention") %></mark></p>
+    <p class="mt-0"><small><%= t("posts.form.code_change.explanation_html", article_url: "https://workshop.codes/wiki/articles/uploading+new+content+to+existing+import+code") %></small></p>
+    <p class="mt-0"><small><%= t("posts.form.code_change.current_code_html", current_code: @post.code) %></small></p>
   </div>
 
   <div class="form-group-uneven mt-1/2" data-reveal-by-select-parent>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -14,6 +14,7 @@
   <div class="well well--dark block warning mt-1/4 mb-1/4 pt-1/8 pb-1/8" data-role="reveal-on-difference" style="display: none">
     <p class="mb-0"><mark>Heads up!</mark></p>
     <p class="mt-0"><small>If you aren't trying to have an import code for each version, you probably want to update your existing import code instead of making a new one. If you're not sure how to do that, read this <a href="https://workshop.codes/wiki/articles/uploading+new+content+to+existing+import+code" target="_blank"><mark>Wiki article</mark></a>.</small></p>
+    <p class="mt-0"><small>In case you forgot, your original import code is <code><%= @post.code %></code></small></p>
   </div>
 
   <div class="form-group-uneven mt-1/2" data-reveal-by-select-parent>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,10 @@ en:
     form:
       title: Title
       code: Code
+      code_change:
+        attention: Heads up!
+        explanation_html: If you aren't trying to have an import code for each version, you probably want to update your existing import code instead of making a new one. If you're not sure how to do that, read this <a href="%{article_url}" target="_blank"><mark>Wiki article</mark></a>.
+        current_code_html: In case you forgot, your original import code is <code>%{current_code}</code>.
       ptr:
         label: PTR Only?
         help: Beware! Once PTR goes down you might lose access to your code. Make sure to copy paste the snippet to easily copy it to Live once the time is there.

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -106,6 +106,10 @@ ko:
     form:
       title: 제목
       code: 코드
+      code_change:
+        attention: 잠깐!
+        explanation_html: 각각의 버전마다 공유 코드를 따로 생성하지 않으신다면, 아마도 당신은 새 공유 코드를 만들기보다 기존의 공유 코드로 계속 업데이트하기를 원하시는 것 같습니다. 어떻게 하는지 잘 모르시겠다면, 이 <a href="%{article_url}" target="_blank"><mark>위키 문서</mark></a>를 참고해주세요.
+        current_code_html: 혹시 잊어버리셨다면, 당신의 기존 공유 코드는 <code>%{current_code}</code>입니다.
       ptr:
         label: 공개 테스트 서버
       public:


### PR DESCRIPTION
It is often the case that newer Workshoppers will not realize that they are able to upload updates to their gamemodes to the existing associated import code. This warning will help educate those people.