### PR TITLE
Improve text and warnings on report form

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,6 +1,8 @@
 module ReportsHelper
   def report_options
     [
+      "There's a bug in this code",
+      "I can't import this code",
       "This code does not work",
       "This code is made by someone else",
       "This is an edit of someone else's code, but no credit is given",

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -22,8 +22,8 @@
         Do not report if:
 
         <ul class="mt-1/8 pl-1/2">
-          <li>This code is less than 6 months old and has not expired.</li>
-          <li>This code not for PTR.</li>
+          <li>This code has expired.</li>
+          <li>This code is made for PTR.</li>
         <ul>
       </div>
     </div>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -10,6 +10,24 @@
     <%= form.label :category, class: "form-label" %>
     <%= form.select :category, options_for_select(report_options), { include_blank: "Select one..." }, class: "form-select", data: { action: "reveal-by-select" }, required: true %>
 
+    <div data-reveal-by-select-target="There's a bug in this code" class="visibility-hidden">
+      <div class="block mt-1/4 text-small text-dark">
+        <strong>Do not use this form!</strong>
+        <u>Instead, please contact the original creator directly!</u>
+      </div>
+    </div>
+
+    <div data-reveal-by-select-target="I can't import this code" class="visibility-hidden">
+      <div class="block mt-1/4 text-small text-dark">
+        Do not report if:
+
+        <ul class="mt-1/8 pl-1/2">
+          <li>This code is less than 6 months old and has not expired.</li>
+          <li>This code not for PTR.</li>
+        <ul>
+      </div>
+    </div>
+
     <div data-reveal-by-select-target="This code does not work" class="visibility-hidden">
       <div class="block mt-1/4 text-small text-dark">
         Do not report if:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,7 +238,7 @@ en:
     action: Report code
     loading: Loading...
     modal:
-      disclaimer_html: <strong>Please note;</strong> This form is meant to report this code to the Workshop.codes admins. This form is not meant to report bugs to the creator of this code.
+      disclaimer_html: <strong>Please note;</strong> This form is meant to report this code to the Workshop.codes admins. <u>This form is not meant to report bugs to the creator of this code.</u>
 
   while_you_waits:
     index:


### PR DESCRIPTION
Add new options to report form:
`There's a bug in this code` and `I can't import this code`
Selecting them reveals additional warnings when reports should not be submitted.
This should reduce the amount of `Other` reports reporting a bug in a code.
![image](https://user-images.githubusercontent.com/23165606/107059875-9a0ae680-67d6-11eb-825e-8d5bb75d3f45.png)
![image](https://user-images.githubusercontent.com/23165606/107059890-9ecf9a80-67d6-11eb-9a39-af919ceaf777.png)
