### PR TITLE
Remove "This code does not work" report category

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -3,7 +3,6 @@ module ReportsHelper
     [
       "There's a bug in this code",
       "I can't import this code",
-      "This code does not work",
       "This code is made by someone else",
       "This is an edit of someone else's code, but no credit is given",
       "This code is inappropriate/offensive",

--- a/app/views/reports/_form_post.html.erb
+++ b/app/views/reports/_form_post.html.erb
@@ -26,17 +26,6 @@
 
         <ul class="mt-1/8 pl-1/2">
           <li>This code has expired.</li>
-          <li>This code is made for PTR.</li>
-        <ul>
-      </div>
-    </div>
-
-    <div data-reveal-by-select-target="This code does not work" class="visibility-hidden">
-      <div class="block mt-1/4 text-small text-dark">
-        Do not report if:
-
-        <ul class="mt-1/8 pl-1/2">
-          <li>This code has expired.</li>
           <li>This code has a snippet.</li>
           <li>This code is for PTR.</li>
           <li>This code is for a different region.</li>


### PR DESCRIPTION
Users would frequently mistake the intent of "This code does not work" to mean that the post did not function as intended, when the true intention was more in line with the "I can't import this code" category.