### PR TITLE
Make disabled buttons actually look disabled by greying them out

### DIFF
--- a/app/assets/stylesheets/elements/_buttons.scss
+++ b/app/assets/stylesheets/elements/_buttons.scss
@@ -28,6 +28,7 @@
 
   &[disabled] {
     opacity: .75;
+    background: $gray-dark;
   }
 
   &--small {


### PR DESCRIPTION
Currently, it is sometimes difficult to tell if a button is disabled or not, because it will appear to have a similar color to its normal appearance. This change prevents that issue by applying a gray background color to the button when it is disabled.﻿

_Example of disabled button (live)_
![image](https://user-images.githubusercontent.com/10406383/120061724-5e10c100-c013-11eb-8901-2b103d27fc6c.png)

_New disabled button_
![image](https://user-images.githubusercontent.com/10406383/120061758-80a2da00-c013-11eb-826e-63b8d5c59f27.png)
