### PR TITLE
Ask Rails to acquire the image URL instead of requiring CDN

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,9 +59,9 @@ class ApplicationController < ActionController::Base
 
     if image.present?
       if params[:type] == "thumbnail"
-        url = ENV["CDN"] + image.variant(quality: 95, resize_to_fill: [120, 120]).processed.key
+        url = rails_public_blob_url(image.variant(quality: 95, resize_to_fill: [120, 120]).processed)
       else
-        url = ENV["CDN"] + image.variant(quality: 95, resize_to_limit: [1920, 1080]).processed.key
+        url = rails_public_blob_url(image.variant(quality: 95, resize_to_limit: [1920, 1080]).processed)
       end
 
       render json: url, layout: false

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -7,7 +7,7 @@ module PostsHelper
         image = post.images.find_by_blob_id(JSON.parse(post.image_order).first)
 
         if image
-          url = ENV["CDN"] + image.variant(quality: 90, resize_to_fill: [width, height], format: :webp).processed.key
+          url = rails_public_blob_url(image.variant(quality: 90, resize_to_fill: [width, height], format: :webp).processed)
         end
       rescue
       end

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -12,7 +12,7 @@ class PostSerializer < ActiveModel::Serializer
       image = object.images.find_by_blob_id(JSON.parse(object.image_order).first)
 
       if image
-        url = ENV["CDN"] + image.variant(quality: 95, resize_to_fill: [690, 394]).processed.key
+        url = rails_public_blob_url(image.variant(quality: 95, resize_to_fill: [690, 394]).processed)
       end
     end
 

--- a/app/views/application/_body_bg.html.erb
+++ b/app/views/application/_body_bg.html.erb
@@ -23,12 +23,12 @@
     <% if yield(:replace_body_bg) == "user" %>
       <source
         srcset="
-          <%= ENV["CDN"] + @user.banner_image.variant(quality: 90, resize_to_fill: [640, 400]).processed.key %> 640w,
-          <%= ENV["CDN"] + @user.banner_image.variant(quality: 90, resize_to_fill: [960, 400]).processed.key %> 960w,
-          <%= ENV["CDN"] + @user.banner_image.variant(quality: 90, resize_to_fill: [1920, 400]).processed.key %> 1920w"
+          <%= rails_public_blob_url(@user.banner_image.variant(quality: 90, resize_to_fill: [640, 400]).processed) %> 640w,
+          <%= rails_public_blob_url(@user.banner_image.variant(quality: 90, resize_to_fill: [960, 400]).processed) %> 960w,
+          <%= rails_public_blob_url(@user.banner_image.variant(quality: 90, resize_to_fill: [1920, 400]).processed) %> 1920w"
         type="image/jpg">
 
-      <%= image_tag ENV["CDN"] + @user.banner_image.variant(quality: 90, resize_to_fill: [1920, 400]).processed.key %>
+      <%= image_tag rails_public_blob_url(@user.banner_image.variant(quality: 90, resize_to_fill: [1920, 400]).processed) %>
     <% end %>
   </picture>
 </div>

--- a/app/views/blocks/post/_gallery.html.erb
+++ b/app/views/blocks/post/_gallery.html.erb
@@ -10,7 +10,7 @@
 <div class="gallery gallery--<%= block.id %>">
   <% images.each do |image| %>
     <% next unless image %>
-    <% url = ENV["CDN"] + image.variant(quality: 95).processed.key %>
+    <% url = rails_public_blob_url(image.variant(quality: 95).processed) %>
     
     <div class="gallery__item" data-action="show-modal set-gallery" data-target="gallery-<%= random_id %>" data-url="<%= url %>">
       <%= image_tag url, alt: "abc", loading: "lazy" %>

--- a/app/views/filter/get_verified_users.html.erb
+++ b/app/views/filter/get_verified_users.html.erb
@@ -3,7 +3,7 @@
 
   <%= link_to build_filter_path(:author, user.username), class: "dropdown__item", data: { action: "add-filter", value: CGI.escape(user.username) } do %>
     <% if user.profile_image.attached? %>
-      <%= image_tag ENV["CDN"] + user.profile_image.variant(quality: 95, resize_to_fill: [30, 30]).processed.key, width: 30, height: 30, loading: "lazy" %>
+      <%= image_tag rails_public_blob_url(user.profile_image.variant(quality: 95, resize_to_fill: [30, 30]).processed), width: 30, height: 30, loading: "lazy" %>
     <% elsif user.provider_profile_image.present? %>
       <%= image_tag user.provider_profile_image, width: 30, height: 30, loading: "lazy" %>
     <% else %>

--- a/app/views/posts/_carousel.html.erb
+++ b/app/views/posts/_carousel.html.erb
@@ -27,7 +27,7 @@
 
         <% @ordered_images.each_with_index do |image, index| %>
           <div class="carousel__navigation-item" data-action="carousel-go-to" data-target="<%= @post.carousel_video.present? ? index + 1 : index %>">
-            <%= image_tag ENV["CDN"] + image.variant(quality: 95, resize_to_fill: [120, 120]).processed.key, aria: { label: "Thumbnail image for '#{ @post.title }'" }, height: 120, width: 120 %>
+            <%= image_tag rails_public_blob_url(image.variant(quality: 95, resize_to_fill: [120, 120]).processed), aria: { label: "Thumbnail image for '#{ @post.title }'" }, height: 120, width: 120 %>
           </div>
         <% end %>
       <% elsif !@ordered_images.present? && @post.carousel_video.present? %>

--- a/app/views/posts/_carousel_item.html.erb
+++ b/app/views/posts/_carousel_item.html.erb
@@ -1,8 +1,8 @@
 <div class="carousel__item">
   <picture>
-    <source media="(min-width: 560px)" <%= "data-" if index >= 2 %>srcset="<%= ENV["CDN"] + image.variant(quality: 95, resize_to_fill: [900, 500]).processed.key %>" type="image/jpeg">
-    <source media="(min-width: 0px)" <%= "data-" if index >= 2 %>srcset="<%= ENV["CDN"] + image.variant(quality: 95, resize_to_fill: [450, 250]).processed.key %>" type="image/jpeg">
-    <img class="img-fluid" <%= "data-" if index >= 2 %>src="<%= ENV["CDN"] + image.variant(quality: 95, resize_to_fill: [900, 500]).processed.key %>" aria-label="Image for '<%= @post.title %>'" width="900" height="500" />
+    <source media="(min-width: 560px)" <%= "data-" if index >= 2 %>srcset="<%= rails_public_blob_url(image.variant(quality: 95, resize_to_fill: [900, 500]).processed) %>" type="image/jpeg">
+    <source media="(min-width: 0px)" <%= "data-" if index >= 2 %>srcset="<%= rails_public_blob_url(image.variant(quality: 95, resize_to_fill: [450, 250]).processed) %>" type="image/jpeg">
+    <img class="img-fluid" <%= "data-" if index >= 2 %>src="<%= rails_public_blob_url(image.variant(quality: 95, resize_to_fill: [900, 500]).processed) %>" aria-label="Image for '<%= @post.title %>'" width="900" height="500" />
   </picture>
 
   <div class="carousel__actions">            
@@ -10,7 +10,7 @@
       class="button button--small button--secondary"
       data-action="show-modal set-gallery"
       data-target="carousel-modal"
-      data-url="<%= ENV["CDN"] + image.variant(quality: 95).processed.key %>">
+      data-url="<%= rails_public_blob_url(image.variant(quality: 95).processed) %>">
       View original size
     </div>
   </div>

--- a/app/views/posts/form/_image_upload.html.erb
+++ b/app/views/posts/form/_image_upload.html.erb
@@ -3,7 +3,7 @@
   <%= form.hidden_field :image_order %>
 
   <%= svelte_component("Dropzone", {
-        images: (@ordered_images || {}).map { |i| { id: i.blob_id, url: ENV["CDN"] + i.variant(quality: 95, resize_to_fill: [120, 120]).processed.key } },
+        images: (@ordered_images || {}).map { |i| { id: i.blob_id, url: rails_public_blob_url(i.variant(quality: 95, resize_to_fill: [120, 120]).processed) } },
         label: t("posts.form.images.dropzone.label"),
         help: t("posts.form.images.dropzone.help"),
         input: "post[images][]",

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{ @post.title }" %>
-<% begin %><% content_for :og_image, "#{ ENV["CDN"] + @ordered_images.first.variant(quality: 95, resize_to_fill: [900, 500]).processed.key if @ordered_images.present? && @ordered_images.any? }" %><% rescue %><% end %>
+<% begin %><% content_for :og_image, "#{ rails_public_blob_url(@ordered_images.first.variant(quality: 95, resize_to_fill: [900, 500]).processed) if @ordered_images.present? && @ordered_images.any? }" %><% rescue %><% end %>
 <% content_for :og_description, strip_tags(markdown(@post.description || "")).truncate(200).gsub("\n"," ") %>
 <% content_for :bg_size, "medium" %>
 

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -60,7 +60,7 @@
           <%= form.label :profile_image, t("profile.form.image.label"), class: "form-label" %>
 
           <div class="profile-image">
-            <%= image_tag (@user.profile_image.attached? ? ENV["CDN"] + @user.profile_image.variant(quality: 95, resize_to_fill: [140, 140]).processed.key : "//:0"),
+            <%= image_tag (@user.profile_image.attached? ? rails_public_blob_url(@user.profile_image.variant(quality: 95, resize_to_fill: [140, 140]).processed) : "//:0"),
                           data: { image_preview: "profile-image" } %>
           </div>
 
@@ -82,7 +82,7 @@
         <%= t "profile.form.banner_image.description" %>
       </p>
 
-      <%= image_tag (@user.banner_image.attached? ? ENV["CDN"] + @user.banner_image.variant(quality: 90, resize_to_fill: [1920, 400]).processed.key : "//:0"),
+      <%= image_tag (@user.banner_image.attached? ? rails_public_blob_url(@user.banner_image.variant(quality: 90, resize_to_fill: [1920, 400]).processed) : "//:0"),
                     class: "mt-1/4 img-fluid",
                     data: { image_preview: "banner" } %>
 

--- a/app/views/profiles/_image.html.erb
+++ b/app/views/profiles/_image.html.erb
@@ -1,6 +1,6 @@
 <% if user.profile_image.attached? %>
   <% begin %>
-    <%= image_tag ENV["CDN"] + user.profile_image.variant(quality: 95, resize_to_fill: [size, size]).processed.key, loading: "lazy", aria: { label: "Profile image of '#{ user.username }'" }, height: size, width: size %>
+    <%= image_tag rails_public_blob_url(user.profile_image.variant(quality: 95, resize_to_fill: [size, size]).processed), loading: "lazy", aria: { label: "Profile image of '#{ user.username }'" }, height: size, width: size %>
   <% rescue %>
   <% end %>
 <% elsif user.provider_profile_image.present? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,4 +150,12 @@ Rails.application.routes.draw do
     post :ko_fi
     get :get_ko_fi_value
   end
+
+  direct :rails_public_blob do |blob|
+    if ENV["CDN"].present?
+      File.join(ENV["CDN"], blob.key)
+    else
+      url_for(blob)
+    end
+  end
 end


### PR DESCRIPTION
This enables developers to test image-related features without needing to possess a CDN. Developers may still choose to use a CDN in development by editing `config/storage.yml`