### PR TITLE
Prefetch links on hover to decrease perceived load times

### DIFF
--- a/app/assets/stylesheets/elements/_carousel.scss
+++ b/app/assets/stylesheets/elements/_carousel.scss
@@ -18,9 +18,7 @@
 }
 
 .carousel__wrapper {
-  background: $bg-darker;
   overflow: hidden;
-  box-shadow: $shadow;
 
   &--is-inactive {
     display: none;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -2,9 +2,11 @@ require("../src/remove-and-add-event-listener")
 
 import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
+import TurbolinksPrefetch from "../src/turbolinks-prefetch"
 
 Rails.start()
 Turbolinks.start()
+TurbolinksPrefetch.start()
 
 import * as analytics from "../src/analytics"
 import * as carousel from "../src/carousel"

--- a/app/javascript/src/turbolinks-prefetch.js
+++ b/app/javascript/src/turbolinks-prefetch.js
@@ -1,0 +1,144 @@
+// Adjusted from https://github.com/huacnlee/turbolinks-prefetch
+// The original NPM package is modified to include links around images
+// and to automatically exclude links with the data-actions attrubute
+
+export default class {
+  static start(delay) {
+    if (!window.Turbolinks) {
+      console.error("window.Turbolinks not found, you must import Turbolinks with global.")
+      return
+    }
+
+
+    const prefetcher = new Prefetcher(window.Turbolinks.controller)
+    prefetcher.start(delay)
+  }
+}
+
+class Prefetcher {
+  start(delay = 100) {
+    this.delay = delay || this.delay
+    document.addEventListener("mouseover", (event) => {
+      this.mouseover(event)
+    })
+  }
+
+  constructor(controller) {
+    this.delay = 100
+    this.fetchers = {}
+    this.doc = document.implementation.createHTMLDocument("prefetch")
+    this.xhr = new XMLHttpRequest()
+    this.controller = controller
+    this.controller.getActionForLink = (link) => {
+      return this.getActionForLink(link)
+    }
+  }
+
+  mouseover(event) {
+    let { target } = event
+    if (target instanceof HTMLImageElement) target = target.closest("a")
+    if (!target) return
+    if (target.hasAttribute("data-action")) return
+    if (target.hasAttribute("data-remote")) return
+    if (target.hasAttribute("data-method")) return
+    if (target.getAttribute("data-prefetch") === "false") return
+    if (target.getAttribute("target") === "_blank") return
+    const href = target.getAttribute("href") || target.getAttribute("data-prefetch")
+
+    // skip no fetch link
+    if (!href) return
+    // skip anchor
+    if (href.startsWith("#")) return
+    // skip mailto
+    if (href.startsWith("mailto:")) return
+    // skip tel
+    if (href.startsWith("tel:")) return
+    // skip outside link
+    if (href.includes("://") && !href.startsWith(window.location.origin)) return
+    if (this.prefetched(href)) return
+    if (this.prefetching(href)) return
+    this.cleanup(event, href)
+    if (event.target) {
+      event.target.addEventListener("mouseleave", (event) => this.mouseleave(event, href))
+      event.target.addEventListener("mousedown", (event) => this.mouseleave(event, href))
+    }
+    this.fetchers[href] = setTimeout(() => this.prefetch(href), this.delay)
+  }
+
+  mouseleave(event, href) {
+    this.xhr.abort()
+    this.cleanup(event, href)
+  }
+
+  cleanup(event, href) {
+    const element = event.target
+    clearTimeout(this.fetchers[href])
+    this.fetchers[href] = null
+    if (element) {
+      element.removeEventListener("mouseleave", (event) => {
+        return this.mouseleave(event)
+      })
+    }
+  }
+
+  fetchPage(url, success) {
+    const { xhr } = this
+    xhr.open("GET", url)
+    xhr.setRequestHeader("Purpose", "prefetch")
+    xhr.setRequestHeader("Accept", "text/html")
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState !== XMLHttpRequest.DONE) return
+      if (xhr.status !== 200) return
+      success(xhr.responseText)
+    }
+    xhr.send()
+  }
+
+  prefetchTurbolink(url) {
+    const { doc } = this
+    this.fetchPage(url, (responseText) => {
+      doc.open()
+      doc.write(responseText)
+      doc.close()
+      this.fetchers[url] = null
+      const snapshot = window.Turbolinks.Snapshot.fromHTMLElement(doc.documentElement)
+      snapshot.isFresh = true
+      this.controller.cache.put(url, snapshot)
+    })
+  }
+
+  prefetch(url) {
+    if (this.prefetched(url)) return
+    this.prefetchTurbolink(url)
+  }
+
+  prefetched(url) {
+    const hasSnapshot = location.href === url || this.controller.cache.has(url)
+    const snapshot = this.controller.cache.get(url)
+    return hasSnapshot && snapshot.isFresh
+  }
+
+  prefetching(url) {
+    return !!this.fetchers[url]
+  }
+
+
+  isAction(action) {
+    return action == "advance" || action == "replace" || action == "restore"
+  }
+
+  getActionForLink(link) {
+    const { controller } = this
+    const location = controller.getVisitableLocationForLink(link)
+    const snapshot = controller.cache.get(location)
+    if (snapshot && snapshot.isFresh) {
+      snapshot.isFresh = false
+      controller.cache.put(link, snapshot)
+      return "restore"
+    }
+
+    const action = link.getAttribute("data-turbolinks-action")
+    return this.isAction(action) ? action : "advance"
+  }
+}
+

--- a/app/views/application/_locale_picker.html.erb
+++ b/app/views/application/_locale_picker.html.erb
@@ -10,7 +10,7 @@
 
     <hr>
 
-    <%= link_to "en - English", url_for(params.clone.permit!.merge(locale: nil)), class: "dropdown__item" %>
-    <%= link_to "ko - 한국어", url_for(params.clone.permit!.merge(locale: :ko)), class: "dropdown__item" %>
+    <%= link_to "en - English", url_for(params.clone.permit!.merge(locale: nil)), class: "dropdown__item", data: { prefetch: false } %>
+    <%= link_to "ko - 한국어", url_for(params.clone.permit!.merge(locale: :ko)), class: "dropdown__item", data: { prefetch: false } %>
   </div>
 </div>

--- a/app/views/application/_user_block.erb
+++ b/app/views/application/_user_block.erb
@@ -6,7 +6,7 @@
       <%= link_to current_user.clean_username, account_path, class: "user-block__action mbl:mr-1/16 mb-1/4 mbl:mb-0", data: { action: "toggle-dropdown" } %>
 
       <div class="dropdown__content lg-down:dropup" data-dropdown-content>
-        <%= link_to t("account.navigation.overview"), account_path, class: "dropdown__item text-small" %>
+        <%= link_to t("account.navigation.overview"), account_path, class: "dropdown__item text-small", data: { prefetch: false } %>
         <%= link_to t("account.navigation.notifications"), notifications_path, class: "dropdown__item text-small" %>
         <%= link_to t("account.navigation.favorites"), account_favorites_path, class: "dropdown__item text-small" %>
         <%= link_to t("account.navigation.codes"), account_posts_path, class: "dropdown__item text-small" %>
@@ -14,11 +14,11 @@
 
         <hr>
 
-        <%= link_to t("account.navigation.admin"), admin_root_path, class: "dropdown__item text-small" if is_admin?(current_user) %>
+        <%= link_to t("account.navigation.admin"), admin_root_path, class: "dropdown__item text-small", data: { prefetch: false } if is_admin?(current_user) %>
         <%= link_to t("account.navigation.profile"), edit_profile_path, class: "dropdown__item text-small" %>
         <%= link_to t("account.navigation.account"), edit_user_path, class: "dropdown__item text-small" %>
         <%= link_to t("account.navigation.accessibility"), accessibility_path, class: "dropdown__item text-small" %>
-        <%= link_to t("account.navigation.logout"), logout_path, class: "dropdown__item text-small" %>
+        <%= link_to t("account.navigation.logout"), logout_path, class: "dropdown__item text-small", data: { prefetch: false } %>
       </div>
     </div>
   <% else %>

--- a/app/views/filter/_filter.html.erb
+++ b/app/views/filter/_filter.html.erb
@@ -112,7 +112,7 @@
         </div>
 
         <div class="filter__group flex mt-1/4">
-          <%= link_to t("filter.apply"), build_filter_path(nil, nil), class: "button button--ghost mr-1/4", data: { role: "filter-link" } %>
+          <%= link_to t("filter.apply"), build_filter_path(nil, nil), class: "button button--ghost mr-1/4", data: { role: "filter-link", prefetch: false } %>
 
           <% if is_filter_active? %>
             <%= link_to t("filter.remove_all"), params[:search] ? "/search/#{ params[:search] }" : posts_path(1), class: "filter__link text-red text-small" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -36,12 +36,12 @@
 
         <hr class="mt-1/2 mb-1/4">
 
-        <%= link_to "/auth/discord", class: "button button--discord mt-1/4" do %>
+        <%= link_to "/auth/discord", class: "button button--discord mt-1/4", data: { prefetch: false } do %>
           <%= inline_svg_tag "discord.svg", height: 24 %>
           <%= t "sessions.login.discord" %>
         <% end %>
 
-        <%= link_to "/auth/bnet", class: "button button--bnet mt-1/8" do %>
+        <%= link_to "/auth/bnet", class: "button button--bnet mt-1/8", data: { prefetch: false } do %>
           <%= inline_svg_tag "bnet.svg", height: 24 %>
           <%= t "sessions.login.battle_net" %>
         <% end %>


### PR DESCRIPTION
When hovering a link the page is prefetched and placed in to Turbolinks cache. The result is that the page starts loading before the user actually clicks, potentially shaving off all perceived load times. The downside is that you're potentially making requests that are never actually visited. All links are prefetched by default, but some links are excluded because either they are too heavy and I don't want to preload them just incase they never get used (e.g. analytics pages), or they don't make sense to prefetch (e.g. log out).

Most of this PR is an edit from an https://github.com/huacnlee/turbolinks-prefetch, which I had to adjust to make more sense for our use case.