### PR TITLE
Fix controls + enable Svelte debugging

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -182,7 +182,7 @@ class Post < ApplicationRecord
   end
 
   def parsed_controls
-    JSON.parse(self.controls)
+    JSON.parse(self.controls).presence || []
   end
 
   def self.find_by_code(code)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -185,7 +185,8 @@ class Post < ApplicationRecord
     begin
       JSON.parse(self.controls).presence || []
     rescue JSON::ParserError
-      self.update controls: "[]"
+      self.controls = "[]"
+      self.save touch: false
       retry
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -182,7 +182,12 @@ class Post < ApplicationRecord
   end
 
   def parsed_controls
-    JSON.parse(self.controls).presence || []
+    begin
+      JSON.parse(self.controls).presence || []
+    rescue JSON::ParserError
+      self.update controls: "[]"
+      retry
+    end
   end
 
   def self.find_by_code(code)

--- a/config/webpack/loaders/svelte.js
+++ b/config/webpack/loaders/svelte.js
@@ -9,6 +9,9 @@ module.exports = {
       preprocess: {
         style: sass()
       },
+      compilerOptions: {
+        dev: process.env.NODE_ENV == 'development' ? true : false,
+      },
       emitCss: true
     }
   }],

--- a/config/webpack/loaders/svelte.js
+++ b/config/webpack/loaders/svelte.js
@@ -10,7 +10,7 @@ module.exports = {
         style: sass()
       },
       compilerOptions: {
-        dev: process.env.NODE_ENV == 'development' ? true : false,
+        dev: process.env.NODE_ENV == 'development' ? true : false
       },
       emitCss: true
     }

--- a/db/migrate/20210908174125_change_post_controls_default.rb
+++ b/db/migrate/20210908174125_change_post_controls_default.rb
@@ -1,0 +1,5 @@
+class ChangePostControlsDefault < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :posts, :controls, from: "{}", to: "[]"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_20_061107) do
+ActiveRecord::Schema.define(version: 2021_09_08_174125) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 2021_05_20_061107) do
     t.datetime "last_revision_created_at"
     t.boolean "immortal", default: false
     t.boolean "draft", default: false
-    t.text "controls", default: "{}"
+    t.text "controls", default: "[]"
     t.integer "min_players"
     t.integer "max_players"
     t.index ["categories"], name: "index_posts_on_categories"


### PR DESCRIPTION
This pull request accomplishes two minor goals:
- Enable loading of Svelte in dev mode within development environments. This change can be used in tandem with a tool such as [Svelte DevTools](https://github.com/RedHatter/svelte-devtools) to enable easier Svelte component debugging.
- Solves #71 by ensuring that undefined controls are re-saved as blank. However, if filled controls are somehow saved as `undefined`, a new issue should be opened.