### PR TITLE
Fix a few bugs with derivative error feedback

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -106,7 +106,13 @@ class PostsController < ApplicationController
     parse_carousel_video
 
     if @post.save
-      parse_derivatives
+      unless parse_derivatives
+        respond_to do |format|
+          format.html { render :new }
+          format.js { render "validation" }
+        end
+        return
+      end
       @revision = Revision.new(post_id: @post.id, code: @post.code, version: @post.version, snippet: @post.snippet).save
 
       create_activity(:create_post, post_activity_params)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -243,7 +243,7 @@ class PostsController < ApplicationController
   end
 
   def parse_derivatives
-    return unless params[:post][:derivatives]
+    return true unless params[:post][:derivatives]
 
     codes = params[:post][:derivatives].split(",")
     trimmed_codes = codes[0, Post::MAX_SOURCES]


### PR DESCRIPTION
- Previously, attempting to create invalid derivatives while creating a post would not show errors, but updating a post would.
- Previously, attempting to update a post with no derivatives would result in a client-side error despite the update happening correctly.