### PR TITLE
chore: Update .gitignore to ignore RSpec results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@
 /config/master.key
 config/local_env.yml
 
+# Ignore RSpec run results
+spec/examples.txt
+
 /public/packs
 /public/packs-test
 /node_modules


### PR DESCRIPTION
The ignored file is solely to support the --only-failures
flag in RSpec, and is not meaningful to include in the repository.
