### PR TITLE
csrf protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem "maxminddb"
 gem "mini_magick", ">= 4.9.5"
 gem "omniauth-bnet"
 gem "omniauth-discord"
+# Mitigate CVE-2015-9284
+gem 'omniauth-rails_csrf_protection'
 gem "puma", "~> 4.3"
 gem "rails", "~> 6.1.0"
 gem "rails-i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,6 +312,9 @@ GEM
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
@@ -507,6 +510,7 @@ DEPENDENCIES
   mini_magick (>= 4.9.5)
   omniauth-bnet
   omniauth-discord
+  omniauth-rails_csrf_protection
   pg
   pry-byebug (~> 3.9.0)
   puma (~> 4.3)

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -36,12 +36,12 @@
 
         <hr class="mt-1/2 mb-1/4">
 
-        <%= link_to "/auth/discord", class: "button button--discord mt-1/4", data: { prefetch: false } do %>
+        <%= link_to "/auth/discord", method: :post, class: "button button--discord mt-1/4", data: { prefetch: false } do %>
           <%= inline_svg_tag "discord.svg", height: 24 %>
           <%= t "sessions.login.discord" %>
         <% end %>
 
-        <%= link_to "/auth/bnet", class: "button button--bnet mt-1/8", data: { prefetch: false } do %>
+        <%= link_to "/auth/bnet", method: :post, class: "button button--bnet mt-1/8", data: { prefetch: false } do %>
           <%= inline_svg_tag "bnet.svg", height: 24 %>
           <%= t "sessions.login.battle_net" %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
     resources :reports, only: [:index, :show]
   end
 
-  get "/auth/:provider/callback", to: "sessions#create", as: "oauth"
+  post "/auth/:provider/callback", to: "sessions#create", as: "oauth"
 
   post "analytics/post", to: "analytics#post", as: "post_analytics"
   post "analytics/user", to: "analytics#user", as: "user_analytics"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
     resources :reports, only: [:index, :show]
   end
 
-  post "/auth/:provider/callback", to: "sessions#create", as: "oauth"
+  get "/auth/:provider/callback", to: "sessions#create", as: "oauth"
 
   post "analytics/post", to: "analytics#post", as: "post_analytics"
   post "analytics/user", to: "analytics#user", as: "user_analytics"

--- a/spec/requests/csrf_requests_spec.rb
+++ b/spec/requests/csrf_requests_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+# Courtesy of https://github.com/omniauth/omniauth/pull/809#issuecomment-512689882
+# Make sure that https://nvd.nist.gov/vuln/detail/CVE-2015-9284 is mitigated
+RSpec.describe "CVE-2015-9284", type: :request do
+  describe "GET /auth/:provider" do
+    it "rejects a call to authenticate with Discord" do
+      expect {
+        get '/auth/discord'
+      }.to raise_error(ActionController::RoutingError)
+    end
+
+    it "rejects a call to authenticate with Battle.net" do
+      expect {
+        get '/auth/bnet'
+      }.to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  describe "POST /auth/:provider without CSRF token" do
+    before do
+      @allow_forgery_protection = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    it "blocks a call to authenticate with Discord" do
+      expect {
+        post '/auth/discord'
+      }.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+
+    it "blocks a call to authenticate with Battle.net" do
+      expect {
+        post '/auth/bnet'
+      }.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = @allow_forgery_protection
+    end
+  end
+end


### PR DESCRIPTION
Mitigates [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284). More information can be found in [this discussion](https://github.com/omniauth/omniauth/pull/809).

﻿- test: Ensure CSRF cannot occur
- fix: Prevent CSRF attacks
- fix: Undo unnecessary restriction to callback
