### PR TITLE
chore: Tag Heroku release versions

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -2,4 +2,5 @@ return unless Rails.env.production?
 
 Bugsnag.configure do |config|
   config.api_key = ENV["BUGSNAG_API_KEY"]
+  config.app_version = ENV["HEROKU_RELEASE_VERSION"]
 end


### PR DESCRIPTION
Previously, Bugsnag could not fully utilize the
new GitHub integration because releases were not
properly tagged. This change enables Bugsnag
to track release versions.﻿
