### PR TITLE
perf: Cache `similar_to` post search

### DIFF
--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -1,6 +1,6 @@
 class FilterController < ApplicationController
   def index
-    @posts = params[:search] ? Post.includes(:user).search(params[:search]).records.select_overview_columns.public? : Post.select_overview_columns.public?
+    @posts = params[:search] ? Post.includes(:user).where(id: Post.search(params[:search])).select_overview_columns.public? : Post.select_overview_columns.public?
 
     @user = User.find_by_username(params[:author]) if params[:author]
     @posts = @posts.where(user_id: @user.present? ? @user.id : -1) if params[:author]

--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -1,6 +1,6 @@
 class FilterController < ApplicationController
   def index
-    @posts = params[:search] ? Post.includes(:user).where(id: Post.search(params[:search])).select_overview_columns.public? : Post.select_overview_columns.public?
+    @posts = params[:search] ? Post.includes(:user).where(id: Post.search(params[:search], bypass_cache: true)).select_overview_columns.public? : Post.select_overview_columns.public?
 
     @user = User.find_by_username(params[:author]) if params[:author]
     @posts = @posts.where(user_id: @user.present? ? @user.id : -1) if params[:author]

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -215,7 +215,7 @@ class PostsController < ApplicationController
 
   def similar_to
     @post = Post.find(params[:id])
-    @posts = ENV["BONSAI_URL"] ? Post.includes(:user).search(@post.tags.presence || @post.title, 4).records.where.not(id: @post.id).select_overview_columns.public?.limit(3) : Post.where.not(id: @post.id).last(3)
+    @posts = ENV["BONSAI_URL"] ? Post.includes(:user).where(id: Post.search(@post.tags.presence || @post.title, 4)).where.not(id: @post.id).select_overview_columns.public?.limit(3) : Post.where.not(id: @post.id).last(3)
 
     if @posts.any?
       render collection: @posts, partial: "card", as: :post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -215,13 +215,7 @@ class PostsController < ApplicationController
 
   def similar_to
     @post = Post.find(params[:id])
-    @posts = if ENV["BONSAI_URL"] then
-        Rails.cache.fetch("#{cache_key_with_version}/similar_to", expires_in: 6.hours) do
-          Post.includes(:user).search(@post.tags.presence || @post.title, 4).records.where.not(id: @post.id).select_overview_columns.public?.limit(3)
-        end
-      else
-        Post.where.not(id: @post.id).last(3)
-      end
+    @posts = ENV["BONSAI_URL"] ? Post.includes(:user).search(@post.tags.presence || @post.title, 4).records.where.not(id: @post.id).select_overview_columns.public?.limit(3) : Post.where.not(id: @post.id).last(3)
 
     if @posts.any?
       render collection: @posts, partial: "card", as: :post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -139,7 +139,7 @@ class Post < ApplicationRecord
   before_destroy { |post| Report.where("concerns_model = ? AND concerns_id = ? AND status = ?", 'post', post.id, 0).update_all(status: "archived") }
 
   def self.search(query, size: 100, bypass_cache: false)
-    Rails.cache.fetch("posts/search/#{Digest::SHA1.hexdigest(query)}/#{size}", expires_in: 30.seconds, force: bypass_cache) do
+    Rails.cache.fetch("posts/search/#{Digest::SHA1.hexdigest(query)}/#{size}", expires_in: (ENV["POST_SEARCH_CACHE_SECONDS"] || 30).to_i.seconds, force: bypass_cache) do
       __elasticsearch__.search({
         from: 0,
         size: size,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -139,7 +139,7 @@ class Post < ApplicationRecord
   before_destroy { |post| Report.where("concerns_model = ? AND concerns_id = ? AND status = ?", 'post', post.id, 0).update_all(status: "archived") }
 
   def self.search(query, size: 100, bypass_cache: false)
-    Rails.cache.fetch("posts/search/#{Digest::SHA1.hexdigest(query)}/#{size}", expires_in: 5.minutes, force: bypass_cache) do
+    Rails.cache.fetch("posts/search/#{Digest::SHA1.hexdigest(query)}/#{size}", expires_in: 30.seconds, force: bypass_cache) do
       __elasticsearch__.search({
         from: 0,
         size: size,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -138,8 +138,8 @@ class Post < ApplicationRecord
   # Ensure unresolved reports about this post are archived
   before_destroy { |post| Report.where("concerns_model = ? AND concerns_id = ? AND status = ?", 'post', post.id, 0).update_all(status: "archived") }
 
-  def self.search(query, size = 100)
-    Rails.cache.fetch("posts/search/#{Digest::SHA1.hexdigest(query)}/#{size}", expires_in: 5.minutes) do
+  def self.search(query, size: 100, bypass_cache: false)
+    Rails.cache.fetch("posts/search/#{Digest::SHA1.hexdigest(query)}/#{size}", expires_in: 5.minutes, force: bypass_cache) do
       __elasticsearch__.search({
         from: 0,
         size: size,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -139,7 +139,7 @@ class Post < ApplicationRecord
   before_destroy { |post| Report.where("concerns_model = ? AND concerns_id = ? AND status = ?", 'post', post.id, 0).update_all(status: "archived") }
 
   def self.search(query, size = 100)
-    Rails.cache.fetch("posts/search/#{Digest::SHA1.hexdigest(query)}/#{size}", expires_in: 15.minutes) do
+    Rails.cache.fetch("posts/search/#{Digest::SHA1.hexdigest(query)}/#{size}", expires_in: 5.minutes) do
       __elasticsearch__.search({
         from: 0,
         size: size,


### PR DESCRIPTION
This prevents refreshes from triggering unnecessary re-requests to
the Elasticsearch cluster, and eases load in general, as the suggested
modes do not need to be immediately updated.

Fixes #90
