### PR TITLE
fix(webpack): "loose" config warnings

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -16,6 +16,10 @@ module.exports = function(api) {
   }
 
   return {
+    assumptions: {
+      privateFieldsAsProperties: true,
+      setPublicClassFields: true
+    },
     presets: [
       isTestEnv && [
         '@babel/preset-env',
@@ -45,17 +49,6 @@ module.exports = function(api) {
       '@babel/plugin-syntax-dynamic-import',
       isTestEnv && 'babel-plugin-dynamic-import-node',
       '@babel/plugin-transform-destructuring',
-      ['@babel/plugin-proposal-private-methods',
-        {
-          loose: true
-        }
-      ],
-      [
-        '@babel/plugin-proposal-class-properties',
-        {
-          loose: true
-        }
-      ],
       [
         '@babel/plugin-proposal-object-rest-spread',
         {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,17 +1,17 @@
 module.exports = function(api) {
-  var validEnv = ['development', 'test', 'production']
-  var currentEnv = api.env()
-  var isDevelopmentEnv = api.env('development')
-  var isProductionEnv = api.env('production')
-  var isTestEnv = api.env('test')
+  const validEnv = ["development", "test", "production"]
+  const currentEnv = api.env()
+  const isDevelopmentEnv = api.env("development")
+  const isProductionEnv = api.env("production")
+  const isTestEnv = api.env("test")
 
   if (!validEnv.includes(currentEnv)) {
     throw new Error(
-      'Please specify a valid `NODE_ENV` or ' +
-        '`BABEL_ENV` environment variables. Valid values are "development", ' +
-        '"test", and "production". Instead, received: ' +
+      "Please specify a valid `NODE_ENV` or " +
+        "`BABEL_ENV` environment variables. Valid values are \"development\", " +
+        "\"test\", and \"production\". Instead, received: " +
         JSON.stringify(currentEnv) +
-        '.'
+        "."
     )
   }
 
@@ -22,47 +22,47 @@ module.exports = function(api) {
     },
     presets: [
       isTestEnv && [
-        '@babel/preset-env',
+        "@babel/preset-env",
         {
           targets: {
-            node: 'current'
+            node: "current"
           }
         }
       ],
       (isProductionEnv || isDevelopmentEnv) && [
-        '@babel/preset-env',
+        "@babel/preset-env",
         {
           targets: {
-            browsers: [ '>2%', 'not ie 11'],
-            node: 'current'
+            browsers: [ ">2%", "not ie 11"],
+            node: "current"
           },
           forceAllTransforms: true,
-          useBuiltIns: 'entry',
+          useBuiltIns: "entry",
           corejs: 3,
           modules: false,
-          exclude: ['transform-typeof-symbol']
+          exclude: ["transform-typeof-symbol"]
         }
       ]
     ].filter(Boolean),
     plugins: [
-      'babel-plugin-macros',
-      '@babel/plugin-syntax-dynamic-import',
-      isTestEnv && 'babel-plugin-dynamic-import-node',
-      '@babel/plugin-transform-destructuring',
+      "babel-plugin-macros",
+      "@babel/plugin-syntax-dynamic-import",
+      isTestEnv && "babel-plugin-dynamic-import-node",
+      "@babel/plugin-transform-destructuring",
       [
-        '@babel/plugin-proposal-object-rest-spread',
+        "@babel/plugin-proposal-object-rest-spread",
         {
           useBuiltIns: true
         }
       ],
       [
-        '@babel/plugin-transform-runtime',
+        "@babel/plugin-transform-runtime",
         {
           helpers: false
         }
       ],
       [
-        '@babel/plugin-transform-regenerator',
+        "@babel/plugin-transform-regenerator",
         {
           async: false
         }


### PR DESCRIPTION
Prevents this set of messages from appearing during the `assets:precompile` phase

```
       Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.

       The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding

       	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]

       to the "plugins" section of your Babel config.
```