### PR TITLE
feat: Update Terms of Service and Privacy Policy

### DIFF
--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,4 +1,5 @@
 <h1 class="heading">Privacy Policy for <strong>Workshop.codes</strong></h1>
+<p><i>Last Updated: January 13th, 2022</i></p>
 
 <p>This page details the data we collect, what we do with collected data, how long we keep that data, and how you can request the deletion of said data.</p>
 

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -2,7 +2,7 @@
 
 <p>This page details the data we collect, what we do with collected data, how long we keep that data, and how you can request the deletion of said data.</p>
 
-<p>Long story short, we keep data collection to a minimum and keep it as impersonal as possible. The only personally identifiable information we collect is email addresses. Providing an email address is always optional, and the email address is encrypted before being stored. However, we rely on third parties to power or enhance your experience on Workshop.codes, and those third parties aren't fully controlled by us.</p>
+<p><b><u>Long story short</u></b>, we keep data collection to a minimum and keep it as impersonal as possible. The only personally identifiable information we collect is email addresses. Providing an email address is always optional, and the email address is encrypted before being stored. However, we rely on third parties to power or enhance your experience on Workshop.codes, and those third parties aren't fully controlled by us.</p>
 
 
 
@@ -21,9 +21,9 @@
 
 <h2 class="mt-1/1" id="data-we-collect">Data We Collect and How We Use It</h2>
 
-<p>When you visit Workshop.codes you are given a token to identify you (hereafter referred to as the visitor token). The visitor token is completely anonymous, cannot be used to identify you personally, and expires after 4 hours of inactivity. Visitor tokens are saved in our database for a maximum of 1 month. An anonymized IP address is saved along with this token. For more information about how we anonymize IP addresses, please read the <%= link_to "Ahoy README", "https://github.com/ankane/ahoy#ip-masking", target: "_blank", rel: "noreferrer noopener" %>.<br></p>
+<p>When you visit Workshop.codes you are given a token to identify you (hereafter referred to as the <b>visitor token</b>). The visitor token is completely anonymous, cannot be used to identify you personally, and expires after 4 hours of inactivity. Visitor tokens are saved in our database for a maximum of 1 month. An anonymized IP address is saved along with this token. For more information about how we anonymize IP addresses, please read the <%= link_to "Ahoy README", "https://github.com/ankane/ahoy#ip-masking", target: "_blank", rel: "noreferrer noopener" %>.<br></p>
 
-<p>We also track certain actions you perform on Workshop.codes (hereafter referred to as action data). Action data are tied to your visitor token and contain no information that could personally identify you. Action data are stored in our database for a maximum of 1 month. We use action data for analytics that are shown to users of this website. For example, action data might be used to show how many visits a specific page has received. Analytics utilizing action data are always shown in aggregate, meaning users cannot identify the visitor tokens involved in action data, let alone the users to which action data are tied.</p>
+<p>We also track certain actions you perform on Workshop.codes (hereafter referred to as <b>action data</b>). Action data are tied to your visitor token and contain no information that could personally identify you. Action data are stored in our database for a maximum of 1 month. We use action data for analytics that are shown to users of this website. For example, action data might be used to show how many visits a specific page has received. Analytics utilizing action data are always shown in aggregate, meaning users cannot identify the visitor tokens involved in action data, let alone the users to which action data are tied.</p>
 
 <p>When you create an account, only the information we ask for is saved. Your username is public. Your password is encrypted before being stored. The use of an email address is completely optional, and provided email addresses are encrypted before being stored. The encryption of email addresses and passwords prevents this data from being read in the event of a data breach without the attacker also compromising the systems which encrypt said data.</p>
 

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -2,7 +2,7 @@
 
 <p>This page details the data we collect, what we do with collected data, how long we keep that data, and how you can request the deletion of said data.</p>
 
-<p>Long story short, we keep data collection to a minimum and keep it as impersonal as possible. The only personally identifiable information we collect is email addresses. Providing an email address is always optional, and the email address is encrypted before being stored.</p>
+<p>Long story short, we keep data collection to a minimum and keep it as impersonal as possible. The only personally identifiable information we collect is email addresses. Providing an email address is always optional, and the email address is encrypted before being stored. However, we rely on third parties to power or enhance your experience on Workshop.codes, and those third parties aren't fully controlled by us.</p>
 
 
 
@@ -83,62 +83,87 @@
 
 <p>Workshop.codes' Privacy Policy does not extend to any third-party services we might use. Thus, we advise you to consult the privacy policies of the third-party services we use (listed below) for more detailed information on their practices and instructions on opting out of certain services.</p>
 
-<p>Please note that certain parts of the privacy policies listed below may not apply to you, the end user, as Workshop.codes communicates with the listed third parties on your behalf. For example, any sections regarding browser cookies do not apply to you, as your browser does not directly connect to the listed third party services when using Workshop.codes.</p>
+<p>Please note that certain parts of the privacy policies listed below may not apply to you, the end user, as Workshop.codes communicates with the listed third parties on your behalf. For example, any sections of privacy policies, besides Google Analytics' privacy policy, regarding browser cookies do not apply to you, as your browser does not store cookies from the listed third parties when using Workshop.codes.</p>
 
 <table>
   <tr>
     <th>Third Party</th>
     <th>Purpose</th>
+    <th>Information provided to third party</th>
     <th>Link to Privacy Policy</th>
+  </tr>
+
+  <tr>
+    <td>Blizzard Entertainment</td>
+    <td>Provide alternative login method</td>
+    <td>Request for authorization on behalf of end user</td>
+    <td><%= link_to "https://www.blizzard.com/en-us/legal/a4380ee5-5c8d-4e3b-83b7-ea26d01a9918/blizzard-entertainment-online-privacy-policy", "https://www.blizzard.com/en-us/legal/a4380ee5-5c8d-4e3b-83b7-ea26d01a9918/blizzard-entertainment-online-privacy-policy", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 
   <tr>
     <td>Bonsai</td>
     <td>Execute search queries</td>
+    <td>Implicit and explicit search queries, post data and post metadata</td>
     <td><%= link_to "https://bonsai.io/privacy", "https://bonsai.io/privacy", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 
   <tr>
     <td>Bugsnag</td>
     <td>Log information about application errors</td>
+    <td>Request metadata*</td>
     <td><%= link_to "https://docs.bugsnag.com/legal/privacy-policy/", "https://docs.bugsnag.com/legal/privacy-policy/", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 
   <tr>
     <td>Cloudflare</td>
     <td>Security and networking</td>
+    <td>Request metadata*, request and response data</td>
     <td><%= link_to "https://www.cloudflare.com/privacypolicy/", "https://www.cloudflare.com/privacypolicy/", target: "_blank", rel: "noreferrer noopener" %></td>
+  </tr>
+
+  <tr>
+    <td>Discord, Inc.</td>
+    <td>Provide alternative login method</td>
+    <td>Request for authorization on behalf of end user</td>
+    <td><%= link_to "https://discord.com/privacy", "https://discord.com/privacy", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 
   <tr>
     <td>Google Analytics</td>
     <td>Site traffic analytics</td>
+    <td>Request metadata*, browser-stored cookies</td>
     <td><%= link_to "https://policies.google.com/privacy", "https://policies.google.com/privacy", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 
   <tr>
     <td>Heroku</td>
     <td>Website hosting</td>
+    <td>Request metadata*, request and response data</td>
     <td><%= link_to "https://www.heroku.com/policy/security", "https://www.heroku.com/policy/security", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 
   <tr>
     <td>Scout APM</td>
     <td>Monitor request performance</td>
+    <td>Request metadata*</td>
     <td><%= link_to "https://scoutapm.com/privacy", "https://scoutapm.com/privacy", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 
   <tr>
     <td>Twillo SendGrid</td>
     <td>Send emails</td>
+    <td>Decrypted email addresses, post data and post metadata</td>
     <td><%= link_to "https://www.twilio.com/legal/privacy", "https://www.twilio.com/legal/privacy", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 </table>
+<p><i>* e.g. full IP address, browser user agent, requested path</i></p>
 
 
 
 <h2 class="mt-1/1" id="removal-of-data">Removal of Data</h2>
 
 <p>If for any reason you wish to delete your account, you can do so from your account settings page. This will delete your account along with any associated data. Your account's data may still exist in backups of our database and in log files for up to 6 months after deletion of your account.</p>
+
+<p>Please contact the third parties listed above individually if you would like to request that they delete any data, as deleting your account will not trigger any request or process resulting in the deletion of your data on third party platforms.</p>
 
 <p>If you cannot access your account, would like us to remove data not related to your account, or have further questions or comments, you may contact us via the #website-discussion channel in the <%= link_to "Elo Hell Workshops Discord", "https://discord.gg/DdxsQRD", target: "_blank", rel: "noreferrer noopener" %> or by any other means listed in the footer below.</p>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -165,6 +165,6 @@
 
 <p>If for any reason you wish to delete your account, you can do so from your account settings page. This will delete your account along with any associated data. Your account's data may still exist in backups of our database and in log files for up to 6 months after deletion of your account.</p>
 
-<p>Please contact the third parties listed above individually if you would like to request that they delete any data, as deleting your account will not trigger any request or process resulting in the deletion of your data on third party platforms.</p>
+<p>Please contact the third parties listed above individually if you would like to request that they delete any data, as deleting your account may not trigger a request or process resulting in the deletion of your data on third party platforms.</p>
 
 <p>If you cannot access your account, would like us to remove data not related to your account, or have further questions or comments, you may contact us via the #website-discussion channel in the <%= link_to "Elo Hell Workshops Discord", "https://discord.gg/DdxsQRD", target: "_blank", rel: "noreferrer noopener" %> or by any other means listed in the footer below.</p>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,9 +1,9 @@
 <h1 class="heading">Privacy Policy for <strong>Workshop.codes</strong></h1>
-<p><i>Last Updated: January 13th, 2022</i></p>
+<p><em>Last Updated: January 13th, 2022</em></p>
 
 <p>This page details the data we collect, what we do with collected data, how long we keep that data, and how you can request the deletion of said data.</p>
 
-<p><b><u>Long story short</u></b>, we keep data collection to a minimum and keep it as impersonal as possible. The only personally identifiable information we collect is email addresses. Providing an email address is always optional, and the email address is encrypted before being stored. However, we rely on third parties to power or enhance your experience on Workshop.codes, and those third parties aren't fully controlled by us.</p>
+<p><strong><u>Long story short</u></strong>, we keep data collection to a minimum and keep it as impersonal as possible. The only personally identifiable information we collect is email addresses. Providing an email address is always optional, and the email address is encrypted before being stored. However, we rely on third parties to power or enhance your experience on Workshop.codes, and those third parties aren't fully controlled by us.</p>
 
 
 
@@ -22,9 +22,9 @@
 
 <h2 class="mt-1/1" id="data-we-collect">Data We Collect and How We Use It</h2>
 
-<p>When you visit Workshop.codes you are given a token to identify you (hereafter referred to as the <b>visitor token</b>). The visitor token is completely anonymous, cannot be used to identify you personally, and expires after 4 hours of inactivity. Visitor tokens are saved in our database for a maximum of 1 month. An anonymized IP address is saved along with this token. For more information about how we anonymize IP addresses, please read the <%= link_to "Ahoy README", "https://github.com/ankane/ahoy#ip-masking", target: "_blank", rel: "noreferrer noopener" %>.<br></p>
+<p>When you visit Workshop.codes you are given a token to identify you (hereafter referred to as the <strong>visitor token</strong>). The visitor token is completely anonymous, cannot be used to identify you personally, and expires after 4 hours of inactivity. Visitor tokens are saved in our database for a maximum of 1 month. An anonymized IP address is saved along with this token. For more information about how we anonymize IP addresses, please read the <%= link_to "Ahoy README", "https://github.com/ankane/ahoy#ip-masking", target: "_blank", rel: "noreferrer noopener" %>.<br></p>
 
-<p>We also track certain actions you perform on Workshop.codes (hereafter referred to as <b>action data</b>). Action data are tied to your visitor token and contain no information that could personally identify you. Action data are stored in our database for a maximum of 1 month. We use action data for analytics that are shown to users of this website. For example, action data might be used to show how many visits a specific page has received. Analytics utilizing action data are always shown in aggregate, meaning users cannot identify the visitor tokens involved in action data, let alone the users to which action data are tied.</p>
+<p>We also track certain actions you perform on Workshop.codes (hereafter referred to as <strong>action data</strong>). Action data are tied to your visitor token and contain no information that could personally identify you. Action data are stored in our database for a maximum of 1 month. We use action data for analytics that are shown to users of this website. For example, action data might be used to show how many visits a specific page has received. Analytics utilizing action data are always shown in aggregate, meaning users cannot identify the visitor tokens involved in action data, let alone the users to which action data are tied.</p>
 
 <p>When you create an account, only the information we ask for is saved. Your username is public. Your password is encrypted before being stored. The use of an email address is completely optional, and provided email addresses are encrypted before being stored. The encryption of email addresses and passwords prevents this data from being read in the event of a data breach without the attacker also compromising the systems which encrypt said data.</p>
 
@@ -157,7 +157,7 @@
     <td><%= link_to "https://www.twilio.com/legal/privacy", "https://www.twilio.com/legal/privacy", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 </table>
-<p><i>* e.g. full IP address, browser user agent, requested path</i></p>
+<p class="text-italic">* e.g. full IP address, browser user agent, requested path</p>
 
 
 

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -52,12 +52,6 @@
   </tr>
 
   <tr>
-    <td>__cfduid</td>
-    <td>This cookie helps Cloudflare detect malicious visitors to our Customers’ websites and minimizes blocking legitimate users. It is necessary to support Cloudflare's security features.<br>
-    More information can be found on <%= link_to "Cloudflare", "https://support.cloudflare.com/hc/en-us/articles/200170156-Understanding-the-Cloudflare-Cookies", target: "_blank", rel: "noreferrer noopener" %>.</td>
-  </tr>
-
-  <tr>
     <td>_gat_gtag_[xxx]</td>
     <td>Used by Google Analytics to throttle request rate.</td>
   </tr>

--- a/app/views/pages/tos.html.erb
+++ b/app/views/pages/tos.html.erb
@@ -1,6 +1,6 @@
 <h1 class="heading">Terms of Service for <strong>Workshop.codes</strong></h1>
 
-<p><i>Last Updated: January 13th, 2022</i></p>
+<p><em>Last Updated: January 13th, 2022</em></p>
 
 <p>The Workshop.codes Terms of Service, which consist of the <%= link_to "Privacy Policy", "/privacy-policy", class: "text-white" %> and the <%= link_to "Rules and Policies", "#site-rules", class: "text-white" %> outlined below, govern your access to and use of our services. By continuing to use Workshop.codes, you agree to be bound by the Terms of Service.</p>
 

--- a/app/views/pages/tos.html.erb
+++ b/app/views/pages/tos.html.erb
@@ -1,5 +1,7 @@
 <h1 class="heading">Terms of Service for <strong>Workshop.codes</strong></h1>
 
+<p><i>Last Updated: January 13th, 2022</i></p>
+
 <p>The Workshop.codes Terms of Service, which consist of the <%= link_to "Privacy Policy", "/privacy-policy", class: "text-white" %> and the <%= link_to "Rules and Policies", "#site-rules", class: "text-white" %> outlined below, govern your access to and use of our services. By continuing to use Workshop.codes, you agree to be bound by the Terms of Service.</p>
 
 <h2 class="mt-1/2 mb-1/2" id="site-rules">Workshop.codes Rules and Policies:</h2>

--- a/app/views/pages/tos.html.erb
+++ b/app/views/pages/tos.html.erb
@@ -42,7 +42,7 @@
       <li><p>Posts whose primary import codes become invalid for any reason, including, but not limited to, expiration or being overwritten by an unrelated creation, are subject to deletion unless said post contains a valid code snippet.</p></li>
     </ol>
 
-    <p>In order to be considered substantive, a post must include some meaningful modification to a base gamemode (e.g. Quick Play, No Limits, Competitive, FFA Deathmatch), whether that be through the custom game settings or the Workshop. This stipulation is to prevent the posting of "spam" modes which essentially look like the author loaded a base preset from the lobby settings and created an import code from it.</p>
+    <p>In order to be considered substantive, a post must include some meaningful modification to a base gamemode (e.g. Quick Play, No Limits, Competitive, FFA Deathmatch), whether that be through the custom game settings or the Workshop. This stipulation is to prevent the posting of "spam" modes which function essentially identically to a provided preset.</p>
   </li>
 
   <li>

--- a/app/views/pages/tos.html.erb
+++ b/app/views/pages/tos.html.erb
@@ -35,12 +35,14 @@
   </li>
 
   <li>
-    <p>Posts must include a valid, in-game generated import code.</p>
+    <p>Posts must be substantive and include a valid, in-game generated import code.</p>
     <ol class="list--lower-alpha">
       <li><p>Please note that import codes generated within the Chinese Overwatch region are not valid for the rest of the world, and thus are not allowed.</p></li>
       <li><p>If an import code is generated on PTR, the post must be flagged as such with the "PTR Only?" checkbox (found within the Settings tab of the post edit page).</p></li>
       <li><p>Posts whose primary import codes become invalid for any reason, including, but not limited to, expiration or being overwritten by an unrelated creation, are subject to deletion unless said post contains a valid code snippet.</p></li>
     </ol>
+
+    <p>In order to be considered substantive, a post must include some meaningful modification to a base gamemode (e.g. Quick Play, No Limits, Competitive, FFA Deathmatch), whether that be through the custom game settings or the Workshop. This stipulation is to prevent the posting of "spam" modes which essentially look like the author loaded a base preset from the lobby settings and created an import code from it.</p>
   </li>
 
   <li>


### PR DESCRIPTION
Some aspects of the Privacy Policy were outdated or misleading, which has been addressed (namely, the deprecation of the Cloudflare cookie). A policy clarification is also included to ensure that users are aware that import codes which function essentially identically to a provided preset are not permitted.

CHANGELOG:
- feat: Remove information about __cfduid
- feat: Update information about third parties in Privacy Policy
- feat: Make Privacy Policy slightly easier to read
- feat: Include Last Updated date on privacy policy
- feat: Add last updated date to ToS
- feat: Add 'substantive' stipulation to terms of service
