### PR TITLE
fix: Rename banner class to standout to fix adblocker blocking the element

### DIFF
--- a/app/assets/stylesheets/elements/_standout.scss
+++ b/app/assets/stylesheets/elements/_standout.scss
@@ -1,4 +1,4 @@
-.banner {
+.standout {
   position: relative;
   padding: $margin / 3 $margin / 4;
   text-align: center;

--- a/app/assets/stylesheets/elements/_tabs.scss
+++ b/app/assets/stylesheets/elements/_tabs.scss
@@ -6,7 +6,7 @@
   overflow-x: auto;
   position: sticky;
 
-  .banner & {
+  .standout & {
     &:not(:first-child) {
       border-radius: 0 0 $border-radius $border-radius;
     }
@@ -91,7 +91,7 @@
     margin: 0 1px;
     padding: $margin / 8;
     border-radius: $border-radius;
-    
+
     &:hover,
     &:active,
     &:focus,

--- a/app/assets/stylesheets/general/_form.scss
+++ b/app/assets/stylesheets/general/_form.scss
@@ -51,7 +51,7 @@
     }
   }
 
-  .banner & {
+  .standout & {
     background: darken($bg-dark, 5%);
   }
 }

--- a/app/views/application/banners/_ko_fi.html.erb
+++ b/app/views/application/banners/_ko_fi.html.erb
@@ -1,4 +1,4 @@
-<div class="banner banner--compact mt-1/1">
+<div class="standout standout--compact mt-1/1">
   <%= inline_svg_tag "badges/ko-fi-supporter.svg", desc: "Ko-fi logo", width: 64, height: 64, class: "ml-1/4 mr-1/2 hidden visible-md" %>
 
   <div class="mr-1/4">

--- a/app/views/posts/form/_form.html.erb
+++ b/app/views/posts/form/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with url: path, model: post, data: { role: "post-form tabs" }, html: { autocomplete: "off" }, remote: true do |form| %>
   <%= render "form_errors", errors: post.errors if post.errors.any? %>
 
-  <div class="banner p-0">
+  <div class="standout p-0">
     <div class="p-1/4">
       <div class="form-group-uneven">
         <div class="form-group mt-0">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,7 +7,7 @@
 
 <div data-role="tabs">
   <div class="pt-1/1 mb-1/1">
-    <div class="banner p-0">
+    <div class="standout p-0">
       <div class="p-1/4 md:p-1/2">
         <%= render "profile", user: @user %>
       </div>


### PR DESCRIPTION
The element would get blocked by some adblockers because `.banner` is identified as an ad. This fixes that by renaming the class to `.standout` (naming is hard ok)