### PR TITLE
ci: Remove environment for some CI tasks

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,7 +28,6 @@ jobs:
           yarn run eslint app/javascript
   test:
     runs-on: ubuntu-latest
-    environment: CI
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -61,7 +60,6 @@ jobs:
   features:
     name: Cucumber Feature Check
     runs-on: ubuntu-latest
-    environment: CI
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The environment was practically useless anyways, since it did not contain any environment variables the workflow did not override or not use altogether.
