### PR TITLE
fix: Allow linking similar-username accounts to verified Battle.net accounts

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,8 +82,8 @@ class User < ApplicationRecord
     # user or a Workshop.codes account colliding with the desired username.
     user.valid? # Trigger validations; we don't care about the result
     if (user.errors[:username].any? && auth_hash["provider"] == "discord")
-      discrimimator = auth_hash["extra"]["raw_info"]["discriminator"]
-      username = username + "#" + discrimimator
+      discriminator = auth_hash["extra"]["raw_info"]["discriminator"]
+      user.username = username + "#" + discriminator
     end
 
     user if user.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class UniquenessAgainstNiceUrlValidator < ActiveModel::Validator
       user_with_nice_url = User.find_by("upper(nice_url) = ?", record.username.upcase)
 
       if user_with_nice_url.present? && user_with_nice_url != record
-        record.errors[:username] << "is not available."
+        record.errors.add(:username, "is not available.")
       end
     end
   end

--- a/features/linking_accounts.feature
+++ b/features/linking_accounts.feature
@@ -34,6 +34,16 @@ Feature: Users can link their accounts and log in with linked accounts
       Then I should see "This log in is already linked to a different account."
       And I should not see "Sojourn#121345" in my linked accounts
 
+    Scenario: User can link a same-name Discord account to a Battle.net account
+      # Check that the discriminator is properly set in a username collision scenario
+      Given I log in with my Battle.net account
+      And the user named "Sojourn#12345" is verified
+      # Need to remove the existing Workhops.codes account to properly test nice_url collision
+      And the user named "Sojourn" is deleted
+      When I try to link my Discord account
+      Then I should see "Your Discord account 'Sojourn#0042' has been linked"
+      And I should see "Sojourn#0042" in my linked accounts
+
   Rule: Users can unlink their accounts
     Background: User has linked accounts
       Given a user named "Sojourn"

--- a/features/linking_accounts.feature
+++ b/features/linking_accounts.feature
@@ -44,6 +44,29 @@ Feature: Users can link their accounts and log in with linked accounts
       Then I should see "Your Discord account 'Sojourn#0042' has been linked"
       And I should see "Sojourn#0042" in my linked accounts
 
+  Rule: Users cannot link existing accounts or their current account
+    Background: Some possible login methods exist
+      Given a user named "Sojourn"
+      * a Battle.net account "Sojourn#12345"
+      * a Discord account "Sojourn#0042"
+      # Need to log in once with each OAuth method to trigger account creation
+      And I log in with my Battle.net account
+      * I log in with my Discord account
+      Then I log in as Sojourn
+
+    Scenario: User cannot link an existing Discord login
+      When I try to link my Discord account
+      Then I should see "An account is already created for this login."
+
+    Scenario: User cannot link an existing Battle.net login
+      When I try to link my Battle.net account
+      Then I should see "An account is already created for this login."
+
+    Scenario: User cannot link their own account
+      Given I log in with my Battle.net account
+      When I try to link my Battle.net account
+      Then I should see "You're already logged in using this login."
+
   Rule: Users can unlink their accounts
     Background: User has linked accounts
       Given a user named "Sojourn"

--- a/features/linking_accounts.feature
+++ b/features/linking_accounts.feature
@@ -31,7 +31,7 @@ Feature: Users can link their accounts and log in with linked accounts
       And I link my Battle.net account
       Then I log in as Sojourn
       And I try to link my Battle.net account
-      Then I should see "This log in is already linked to a different account."
+      Then I should see "This login is already linked to a different account."
       And I should not see "Sojourn#121345" in my linked accounts
 
     Scenario: User can link a same-name Discord account to a Battle.net account

--- a/features/step_definitions/authentication_stepdefs.rb
+++ b/features/step_definitions/authentication_stepdefs.rb
@@ -65,14 +65,26 @@ def oauth_username_to_mock_uid(provider, username)
 end
 
 def stub_oauth_flow(provider, username, &block)
-  OmniAuth.config.add_mock(provider.to_sym, {
+  base_mock = {
     uid: oauth_username_to_mock_uid(provider, username),
     provider: provider,
     info: {
       name: username,
       image: "https://ehe.gg/media/img/logos/Elo-Hell-Logo_I-C-Dark.png"
     }
-  })
+  }
+  # Discord-specific adjustments
+  # ! If needed in the future for other services,
+  # ! can refactor adjustments into a dedicated method
+  if provider == "discord"
+    base_mock[:info][:name] = username.split("#").first
+    base_mock[:extra] = {
+      raw_info: {
+        discriminator: username.split("#").last
+      }
+    }
+  end
+  OmniAuth.config.add_mock(provider.to_sym, base_mock)
   block.call
   OmniAuth.config.mock_auth[provider.to_sym] = nil
 end

--- a/features/step_definitions/user_stepdefs.rb
+++ b/features/step_definitions/user_stepdefs.rb
@@ -7,3 +7,13 @@ Given /an admin named "([\d\p{L}_-]*[#\d]*)"(?: with password "([^"\n]+)")?/ do 
   password ||= 'password'
   @last_created_user = create(:user, username: username, password: password, level: "admin")
 end
+
+Given /the user named "([\d\p{L}_-]*[#\d]*)" is deleted/ do |username|
+  User.find_by_username(username).destroy
+end
+
+Given /the user named "([\d\p{L}_-]*[#\d]*)" is verified/ do |username|
+  user = User.find_by(username: username)
+  user.update(nice_url: user.clean_username)
+  user.update(verified: true)
+end


### PR DESCRIPTION
This pull request fixes an issue where verified users who logged in via Battle.net could not link their similarly-named Discord accounts.

I also took the opportunity to flesh out the test suite for linked accounts.
