### PR TITLE
feat: Lazy load similar codes when scrolled to

### DIFF
--- a/app/javascript/src/get-partial.js
+++ b/app/javascript/src/get-partial.js
@@ -4,19 +4,33 @@ export function bind() {
   const elements = document.querySelectorAll("[data-action~='get-partial']")
 
   elements.forEach(element => {
-    element.removeAndAddEventListener("click", getPartial)
-
     if (element.dataset.getOnLoad == "true") getPartial(event, element)
+    if (element.dataset.lazy == "true") {
+      document.removeAndAddEventListener("scroll", () => lazyLoadGetPartial(element), { passive: true })
+      lazyLoadGetPartial(element)
+    }
+    else element.removeAndAddEventListener("click", getPartial)
   })
+}
+
+function lazyLoadGetPartial(element) {
+  if (element.dataset.initialised == "true") return
+
+  const threshold = 100
+
+  if (element.getBoundingClientRect().top - window.outerHeight > threshold) return
+
+  element.dataset.initialised = "true"
+  getPartial(event, element)
 }
 
 function getPartial(event, element) {
   event.preventDefault()
-  
+
   const _this = element || event.target
   const targetElement = document.querySelector(`[data-partial="${ _this.dataset.target }"]`)
   const url = _this.dataset.url
-  
+
   if (targetElement.dataset.loaded == "true") return
 
   new FetchRails(url).get()

--- a/app/javascript/src/get-partial.js
+++ b/app/javascript/src/get-partial.js
@@ -5,27 +5,26 @@ export function bind() {
 
   elements.forEach(element => {
     if (element.dataset.getOnLoad == "true") getPartial(event, element)
-    if (element.dataset.lazy == "true") {
-      document.removeAndAddEventListener("scroll", () => lazyLoadGetPartial(element), { passive: true })
-      lazyLoadGetPartial(element)
-    }
+    if (element.dataset.lazy == "true") setObserver(element)
     else element.removeAndAddEventListener("click", getPartial)
   })
 }
 
-function lazyLoadGetPartial(element) {
-  if (element.dataset.initialised == "true") return
+function setObserver(element) {
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) return
 
-  const threshold = 100
+      getPartial(null, element)
+      observer.unobserve(element)
+    })
+  })
 
-  if (element.getBoundingClientRect().top - window.outerHeight > threshold) return
-
-  element.dataset.initialised = "true"
-  getPartial(event, element)
+  observer.observe(element)
 }
 
 function getPartial(event, element) {
-  event.preventDefault()
+  if (event) event.preventDefault()
 
   const _this = element || event.target
   const targetElement = document.querySelector(`[data-partial="${ _this.dataset.target }"]`)

--- a/app/javascript/src/remove-and-add-event-listener.js
+++ b/app/javascript/src/remove-and-add-event-listener.js
@@ -2,3 +2,8 @@ Element.prototype.removeAndAddEventListener = function(event, funct) {
   this.removeEventListener(event, funct)
   this.addEventListener(event, funct)
 }
+
+Document.prototype.removeAndAddEventListener = function(event, funct) {
+  this.removeEventListener(event, funct)
+  this.addEventListener(event, funct)
+}

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -17,7 +17,7 @@
     <small class="button-label">&nbsp; <%= t "comment.max_characters", count: 2000 %></small>
   <% end %>
 <% else %>
-  <div class="well well--dark block mb-1/2">
+  <div class="well well--dark block <%= 'mb-1/2' unless @comments.size %>">
     <%= link_to t("comment.log_in"), login_path, class: "text-white" %> or <%= link_to t("comment.sign_up"), new_user_path, class: "text-white" %> to place a comment.
   </div>
 <% end %>

--- a/app/views/posts/_similar_to.html.erb
+++ b/app/views/posts/_similar_to.html.erb
@@ -2,7 +2,12 @@
   <h2 class="mb-0"><strong>Similar</strong> Codes</h2>
 </div>
 
-<div data-action="get-partial" data-get-on-load="true" data-target="similar-posts" data-url="<%= similar_posts_url(@post.id) %>"></div>
+<div
+  data-action="get-partial"
+  data-lazy="true"
+  data-target="similar-posts"
+  data-url="<%= similar_posts_url(@post.id) %>"></div>
+
 <div class="cards" data-partial="similar-posts">
   <div class="infinite-scroll"><div class="spinner"></div></div>
 </div>


### PR DESCRIPTION
This PR makes it so the Similar Codes on post/show only load if they are actually scrolled to. This is to prevent unnecessary calls to ElasticSearch for something that may never get seen.

You can now pass `data-lazy="true"` to an element with `data-action="get-partial"` to lazy load it on scroll. This same function can be used to either load immediately on page load or load on click. It's currently only used for these similar codes, so the other functions are a little redundant, but might as well keep them for some other time.