### PR TITLE
fix: Handle errors when favoriting

### DIFF
--- a/app/assets/stylesheets/elements/_alert.scss
+++ b/app/assets/stylesheets/elements/_alert.scss
@@ -36,6 +36,7 @@
 
   button {
     background-color: transparent;
+    font-size: 0.75rem;
   }
 
   p {

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -3,10 +3,10 @@ class FavoritesController < ApplicationController
     @favorite = Favorite.new(favorite_params)
     @favorite.user_id = current_user.id
 
-    @post = Post.find(favorite_params[:post_id])
+    @post = Post.find_by(id: favorite_params[:post_id])
 
     respond_to do |format|
-      if @favorite.save
+      if @post.present? && @favorite.save
         BadgesFavoritesJob.perform_async(@post, current_user)
 
         format.js
@@ -20,10 +20,10 @@ class FavoritesController < ApplicationController
   def destroy
     @favorite = Favorite.find_by_post_id_and_user_id(favorite_params[:post_id], current_user.id)
 
-    @post = Post.find(favorite_params[:post_id])
+    @post = Post.find_by(id: favorite_params[:post_id])
 
     respond_to do |format|
-      if @favorite.destroy
+      if @post.present? && @favorite.destroy
         format.js
         format.html { redirect_to root_path }
       else

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -18,12 +18,11 @@ class FavoritesController < ApplicationController
   end
 
   def destroy
-    @favorite = Favorite.find_by_post_id_and_user_id(favorite_params[:post_id], current_user.id)
-
+    @favorite = Favorite.find_by(post_id: favorite_params[:post_id], user_id: current_user.id)
     @post = Post.find_by(id: favorite_params[:post_id])
 
     respond_to do |format|
-      if @post.present? && @favorite.destroy
+      if @post.present? && @favorite&.destroy
         format.js
         format.html { redirect_to root_path }
       else

--- a/app/views/application/error.js.erb
+++ b/app/views/application/error.js.erb
@@ -4,7 +4,7 @@
   textNode.innerText = "<%= @message || 'Something went wrong when performing that action.' %>"
 
   const closeButton = document.createElement("button", { "data-role": "dismiss-parent" })
-  closeButton.classList.add("button", "p-0", "pl-1/16", "pr-1/16", "text-white")
+  closeButton.classList.add("button", "button--link", "p-0", "pl-1/16", "pr-1/16")
   closeButton.dataset.role = "dismiss-parent"
   closeButton.innerText = "✕"
 

--- a/app/views/application/success.js.erb
+++ b/app/views/application/success.js.erb
@@ -4,7 +4,7 @@
   textNode.innerText = "<%= @message || 'Successfully saved.' %>"
 
   const closeButton = document.createElement("button", { "data-role": "dismiss-parent" })
-  closeButton.classList.add("button", "p-0", "pl-1/16", "pr-1/16", "text-white")
+  closeButton.classList.add("button", "button--link", "p-0", "pl-1/16", "pr-1/16")
   closeButton.dataset.role = "dismiss-parent"
   closeButton.innerText = "✕"
 


### PR DESCRIPTION
Sometimes when favoriting or removing a favorite the post can not be found. I'm not sure why this happens, but it does. This now brings up an alert showing that something went wrong.

![image](https://user-images.githubusercontent.com/12848235/163629402-1adcb9d7-84d7-4472-9ce4-887452318342.png)

I've also slightly tweaked the styling of the close button of the alert, making it a little smaller.

![image](https://user-images.githubusercontent.com/12848235/163629288-7aeb84a3-d2f9-47b5-990e-98698daf37fa.png)
