### PR TITLE
Update OW2 Beta information/features

### DIFF
--- a/app/views/filter/index.html.erb
+++ b/app/views/filter/index.html.erb
@@ -33,14 +33,9 @@
       </h3>
 
       <div class="mt-1/4 text-small">
-        <s>
-          These Workshop codes were tagged as being importable within the Overwatch 2 Beta.
-          It is possible that codes may have been invalidated, since the Overwatch 2 Beta is under active development.
-        </s>
-
-        <big class="block mt-1/4">
-          The Workshop is currently <strong><u>not</u></strong> available in the beta, sorry.
-        </big>
+        These Workshop codes were tagged as being importable within the Overwatch 2 Beta.
+        It is possible that codes may have been invalidated, since the Overwatch 2 Beta is under active development.
+        An import code that was created in Overwatch 2 Beta will not work in Overwatch 1.
       </div>
     </div>
   </div>

--- a/app/views/filter/index.html.erb
+++ b/app/views/filter/index.html.erb
@@ -33,9 +33,15 @@
       </h3>
 
       <div class="mt-1/4 text-small">
-        These Workshop codes were tagged as being importable within the Overwatch 2 Beta.
-        It is possible that codes may have been invalidated, since the Overwatch 2 Beta is under active development.
-        An import code that was created in Overwatch 2 Beta will not work in Overwatch 1.
+        <p>
+          These codes were tagged as being importable within the Overwatch 2 Beta.
+          It is possible that codes may have been invalidated, since the Overwatch 2 Beta is under active development.
+          An import code that was created in Overwatch 2 Beta will not work in Overwatch 1.
+        </p>
+        <p>
+          The Workshop is unfortunately <strong><u>not</u></strong> currently available in the beta.
+          However, custom lobby settings can still be shared with import codes.
+        </p>
       </div>
     </div>
   </div>

--- a/app/views/posts/form/tabs/_settings.html.erb
+++ b/app/views/posts/form/tabs/_settings.html.erb
@@ -61,27 +61,25 @@
         </div>
       <% end %>
 
-      <% if false %>
-        <div class="well well--dark b-overwatch-2">
-          <div class="switch-checkbox ">
-            <%= form.check_box :overwatch_2_compatible,
-                checked: @post.overwatch_2_compatible?,
-                class: "switch-checkbox__input",
-                data: { action: "reveal-by-checkbox" },
-                autocomplete: "off" %>
+      <div class="well well--dark b-overwatch-2">
+        <div class="switch-checkbox ">
+          <%= form.check_box :overwatch_2_compatible,
+              checked: @post.overwatch_2_compatible?,
+              class: "switch-checkbox__input",
+              data: { action: "reveal-by-checkbox" },
+              autocomplete: "off" %>
 
-            <%= form.label :overwatch_2_compatible,
-                t("posts.form.overwatch_2_compatible.label"),
-                class: "switch-checkbox__label" %>
-          </div>
-
-          <div data-role="hidden-by-checkbox" style="<%= "display: none" unless @post.overwatch_2_compatible? %>">
-            <p class="form-hint mb-0">
-              <%= t("posts.form.overwatch_2_compatible.help") %>
-            </p>
-          </div>
+          <%= form.label :overwatch_2_compatible,
+              t("posts.form.overwatch_2_compatible.label"),
+              class: "switch-checkbox__label" %>
         </div>
-      <% end %>
+
+        <div data-role="hidden-by-checkbox" style="<%= "display: none" unless @post.overwatch_2_compatible? %>">
+          <p class="form-hint mb-0">
+            <%= t("posts.form.overwatch_2_compatible.help") %>
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
The OW2 Beta currently has import codes, but no Workshop. This PR updates the site to reflect that.

Commits:
- Revert "fix: Disable OW2 for now and display a message on the filter page"
- feat: Add explanation of OW2 Beta lobbies
