### PR TITLE
feat: Add graceful UX for search page errors

### DIFF
--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -24,7 +24,7 @@ class FilterController < ApplicationController
       @posts = Kaminari.paginate_array(@posts).page(params[:page])
     rescue Elasticsearch::Transport::Transport::ServerError => e
       Bugsnag.notify(e) if Rails.env.production?
-      @posts = []
+      @posts = Kaminari.paginate_array([]).page(params[:page])
       @message = "Something went wrong. Please try again later."
       flash[:error] = @message
       respond_to do |format|

--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -1,6 +1,5 @@
 class FilterController < ApplicationController
   def index
-    # binding.pry
     begin
       @posts = params[:search] ? Post.includes(:user).where(id: Post.search(params[:search], bypass_cache: true)).select_overview_columns.public? : Post.select_overview_columns.public?
 

--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -28,7 +28,7 @@ class FilterController < ApplicationController
       @message = "Something went wrong. Please try again later."
       flash[:error] = @message
       respond_to do |format|
-        format.html { render :index, status: 500 }
+        format.html { render "errors/internal_error", status: 500 }
         format.js { render "posts/infinite_scroll_posts", status: 500 }
         format.json { render json: { message: @message }, status: 500 }
       end

--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -28,7 +28,7 @@ class FilterController < ApplicationController
       @message = "Something went wrong. Please try again later."
       flash[:error] = @message
       respond_to do |format|
-        format.html { render "errors/internal_error", status: 500 }
+        format.html { render "filter/index", status: 500 }
         format.js { render "posts/infinite_scroll_posts", status: 500 }
         format.json { render json: { message: @message }, status: 500 }
       end

--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -24,8 +24,8 @@ class FilterController < ApplicationController
     rescue Elasticsearch::Transport::Transport::ServerError => e
       Bugsnag.notify(e) if Rails.env.production?
       @posts = Kaminari.paginate_array([]).page(params[:page])
-      @message = "Something went wrong. Please try again later."
-      flash[:error] = @message
+      @error = "Something went wrong. Please try again later."
+      flash[:error] = @error
       respond_to do |format|
         format.html { render "filter/index", status: 500 }
         format.js { render "posts/infinite_scroll_posts", status: 500 }

--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -1,25 +1,39 @@
 class FilterController < ApplicationController
   def index
-    @posts = params[:search] ? Post.includes(:user).where(id: Post.search(params[:search], bypass_cache: true)).select_overview_columns.public? : Post.select_overview_columns.public?
+    # binding.pry
+    begin
+      @posts = params[:search] ? Post.includes(:user).where(id: Post.search(params[:search], bypass_cache: true)).select_overview_columns.public? : Post.select_overview_columns.public?
 
-    @user = User.find_by_username(params[:author]) if params[:author]
-    @posts = @posts.where(user_id: @user.present? ? @user.id : -1) if params[:author]
+      @user = User.find_by_username(params[:author]) if params[:author]
+      @posts = @posts.where(user_id: @user.present? ? @user.id : -1) if params[:author]
 
-    @posts = @posts.where(locale: params[:language]) if params[:language]
-    @posts = @posts.where("created_at >= ?", params[:from]) if params[:from]
-    @posts = @posts.where("created_at <= ?", params[:to]) if params[:to]
-    @posts = @posts.where("last_revision_created_at > ?", 6.months.ago) if params[:expired]
-    @posts = @posts.where("overwatch_2_compatible", true) if params[:overwatch_2]
+      @posts = @posts.where(locale: params[:language]) if params[:language]
+      @posts = @posts.where("created_at >= ?", params[:from]) if params[:from]
+      @posts = @posts.where("created_at <= ?", params[:to]) if params[:to]
+      @posts = @posts.where("last_revision_created_at > ?", 6.months.ago) if params[:expired]
+      @posts = @posts.where("overwatch_2_compatible", true) if params[:overwatch_2]
 
-    @posts = @posts.order("#{ sort_switch } DESC") if params[:sort]
+      @posts = @posts.order("#{ sort_switch } DESC") if params[:sort]
 
-    @posts = @posts.select { |post| to_slug(post.categories).include?(to_slug(params[:category])) } if params[:category]
-    @posts = @posts.select { |post| to_slug(post.maps).include?(to_slug(params[:map])) } if params[:map]
-    @posts = @posts.select { |post| to_slug(post.heroes).include?(to_slug(params[:hero])) } if params[:hero]
-    @posts = @posts.select { |post| helpers.has_player_range?(post) && to_range(params[:players]).overlaps?((post.min_players)..(post.max_players)) } if params[:players]
-    @posts = @posts.select { |post| post.code.upcase.start_with?(params[:code].upcase) } if params[:code]
+      @posts = @posts.select { |post| to_slug(post.categories).include?(to_slug(params[:category])) } if params[:category]
+      @posts = @posts.select { |post| to_slug(post.maps).include?(to_slug(params[:map])) } if params[:map]
+      @posts = @posts.select { |post| to_slug(post.heroes).include?(to_slug(params[:hero])) } if params[:hero]
+      @posts = @posts.select { |post| helpers.has_player_range?(post) && to_range(params[:players]).overlaps?((post.min_players)..(post.max_players)) } if params[:players]
+      @posts = @posts.select { |post| post.code.upcase.start_with?(params[:code].upcase) } if params[:code]
 
-    @posts = Kaminari.paginate_array(@posts).page(params[:page])
+      @posts = Kaminari.paginate_array(@posts).page(params[:page])
+    rescue Elasticsearch::Transport::Transport::ServerError => e
+      Bugsnag.notify(e) if Rails.env.production?
+      @posts = []
+      @message = "Something went wrong. Please try again later."
+      flash[:error] = @message
+      respond_to do |format|
+        format.html { render :index, status: 500 }
+        format.js { render "posts/infinite_scroll_posts", status: 500 }
+        format.json { render json: { message: @message }, status: 500 }
+      end
+      return
+    end
 
     respond_to do |format|
       format.html

--- a/app/javascript/src/infinite-scroll.js
+++ b/app/javascript/src/infinite-scroll.js
@@ -64,6 +64,20 @@ function getInfiniteScrollContent(element) {
         element.innerHTML = "Load more"
         element.setAttribute("data-url", nextUrl)
       }
+    },
+    error: (error) => {
+      progressBar.setValue(1)
+      progressBar.hide()
+
+      const spinner = document.querySelector(".items").querySelector(".spinner")
+      if (spinner) spinner.remove()
+      if (element.classList.contains("button")) {
+        element.innerHTML = "An error occurred. Try again?"
+        element.setAttribute("data-url", currentUrl)
+      }
+
+      const button = document.querySelector("[data-role='load-more-posts']")
+      if (button) button.removeAndAddEventListener("click", loadMorePosts)
     }
   })
 }

--- a/app/javascript/src/infinite-scroll.js
+++ b/app/javascript/src/infinite-scroll.js
@@ -69,7 +69,7 @@ function getInfiniteScrollContent(element) {
       progressBar.setValue(1)
       progressBar.hide()
 
-      const spinner = document.querySelector(".items").querySelector(".spinner")
+      const spinner = document.querySelector(".items")?.querySelector(".spinner")
       if (spinner) spinner.remove()
       if (element.classList.contains("button")) {
         element.innerHTML = "An error occurred. Try again?"

--- a/app/javascript/src/infinite-scroll.js
+++ b/app/javascript/src/infinite-scroll.js
@@ -60,7 +60,7 @@ function getInfiniteScrollContent(element) {
 
       const spinner = document.querySelector(".items").querySelector(".spinner")
       if (spinner) spinner.remove()
-      if (element.classList.contains("button")) {
+      if (element.dataset.loadMethod === "load-more-button") {
         element.innerHTML = "Load more"
         element.setAttribute("data-url", nextUrl)
       }
@@ -71,13 +71,14 @@ function getInfiniteScrollContent(element) {
 
       const spinner = document.querySelector(".items")?.querySelector(".spinner")
       if (spinner) spinner.remove()
-      if (element.classList.contains("button")) {
+      if (element.dataset.loadMethod === "load-more-button") {
         element.innerHTML = "An error occurred. Try again?"
-        element.setAttribute("data-url", currentUrl)
+      } else if (element.dataset.loadMethod === "infinite-scroll") {
+        const button = document.querySelector("[data-role='load-more-posts']")
+        button.innerHTML = "An error occurred. Try again?"
+        if (button) button.removeAndAddEventListener("click", loadMorePosts)
       }
 
-      const button = document.querySelector("[data-role='load-more-posts']")
-      if (button) button.removeAndAddEventListener("click", loadMorePosts)
     }
   })
 }

--- a/app/views/filter/index.html.erb
+++ b/app/views/filter/index.html.erb
@@ -10,18 +10,22 @@
 
 <div class="heading mb-1/2">
   <h2>
-    Workshop Codes
-    <% if params[:overwatch_2] %> for  <strong class="text-overwatch-2">Overwatch 2</strong> <% end %>
-    <% if params[:search] %> for <strong><%= CGI.unescape(params[:search]) %></strong> <% end %>
-    <% if params[:category] %> in <strong><%= params[:category].gsub("-", " ").split.map(&:capitalize).join(" ") %></strong> <% end %>
-    <% if params[:hero] %> with <strong><%= params[:hero].gsub("-", " ").split.map(&:capitalize).join(" ") %></strong> <% end %>
-    <% if params[:map] %> on <strong><%= params[:map].gsub("-", " ").split.map(&:capitalize).join(" ") %></strong> <% end %>
-    <% if params[:from] %> from <strong><%= time_ago_in_words(params[:from]).gsub("about", "") %> ago</strong> <% end %>
-    <% if params[:to] %> to <strong><%= time_ago_in_words(params[:to]).gsub("about", "") %> ago</strong> <% end %>
-    <% if params[:sort] %> sorted by <strong><%= params[:sort].gsub("-", " ") %></strong> <% end %>
-    <% if params[:expired] %> excluding <strong>expired</strong> <% end %>
-    <% if params[:author] %> by <strong><%= params[:author].split("#")[0] %></strong> <% end %>
-    <%= tag.small "- Page #{ params[:page] }" if params[:page] %>
+    <% if flash[:error] %>
+      Something went wrong while performing your search.
+    <% else %>
+      Workshop Codes
+      <% if params[:overwatch_2] %> for  <strong class="text-overwatch-2">Overwatch 2</strong> <% end %>
+      <% if params[:search] %> for <strong><%= CGI.unescape(params[:search]) %></strong> <% end %>
+      <% if params[:category] %> in <strong><%= params[:category].gsub("-", " ").split.map(&:capitalize).join(" ") %></strong> <% end %>
+      <% if params[:hero] %> with <strong><%= params[:hero].gsub("-", " ").split.map(&:capitalize).join(" ") %></strong> <% end %>
+      <% if params[:map] %> on <strong><%= params[:map].gsub("-", " ").split.map(&:capitalize).join(" ") %></strong> <% end %>
+      <% if params[:from] %> from <strong><%= time_ago_in_words(params[:from]).gsub("about", "") %> ago</strong> <% end %>
+      <% if params[:to] %> to <strong><%= time_ago_in_words(params[:to]).gsub("about", "") %> ago</strong> <% end %>
+      <% if params[:sort] %> sorted by <strong><%= params[:sort].gsub("-", " ") %></strong> <% end %>
+      <% if params[:expired] %> excluding <strong>expired</strong> <% end %>
+      <% if params[:author] %> by <strong><%= params[:author].split("#")[0] %></strong> <% end %>
+      <%= tag.small "- Page #{ params[:page] }" if params[:page] %>
+    <% end %>
   </h2>
 </div>
 

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -5,13 +5,13 @@
 
       <% if @posts.size == 20 %>
         <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
-          <div class="infinite-scroll" data-role="infinite-scroll-marker" data-url="<%= request.original_url %>"></div>
+          <div class="infinite-scroll" data-role="infinite-scroll-marker" data-load-method="infinite-scroll" data-url="<%= request.original_url %>"></div>
         <% end %>
 
         <% if current_user && current_user.pagination_type == "load_more" %>
           <div data-role="load-more-posts-marker"></div>
           <div class="flex justify-center">
-            <div class="mt-1/2 button button--secondary pr-1/1 pl-1/1" data-role="load-more-posts" data-url="<%= request.original_url %>">Load more</div>
+            <div class="mt-1/2 button button--secondary pr-1/1 pl-1/1" data-role="load-more-posts" data-load-method="load-more-button" data-url="<%= request.original_url %>">Load more</div>
           </div>
         <% end %>
       <% end %>

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -16,7 +16,11 @@
         <% end %>
       <% end %>
     <% else %>
-      <p><em>There doesn't seem to be anything here</em></p>
+      <% if flash[:error] %>
+        <div><button class="button" onclick="location.reload()">Try again?</button></div>
+      <% else %>
+        <p><em>There doesn't seem to be anything here</em></p>
+      <% end %>
 
       <blockquote>
         <% quote = quotes.sample %>

--- a/app/views/posts/infinite_scroll_posts.js.erb
+++ b/app/views/posts/infinite_scroll_posts.js.erb
@@ -14,6 +14,12 @@
     <% end %>
   <% elsif @posts.any? %>
     <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
+      <%# Remove the error button if the request succeeds after retry %>
+      const button = document.querySelector("[data-role='load-more-posts']")
+      if (button) {
+        button.remove()
+      }
+
       const elements = document.querySelectorAll("[data-role='infinite-scroll-marker']")
 
       elements[elements.length - 1].insertAdjacentHTML("afterEnd", `

--- a/app/views/posts/infinite_scroll_posts.js.erb
+++ b/app/views/posts/infinite_scroll_posts.js.erb
@@ -1,5 +1,5 @@
 (() => {
-  <% if flash[:error].present? %>
+  <% if @error.present? %>
     <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
       const elements = document.querySelectorAll("[data-role='infinite-scroll-marker']")
 
@@ -7,7 +7,7 @@
       if (!button) {
         elements[elements.length - 1].insertAdjacentHTML("afterEnd", `
           <div class="flex justify-center">
-            <div class="mt-1/2 button button--secondary pr-1/1 pl-1/1" data-role="load-more-posts" data-url="<%= request.original_url %>">An error occurred. Try again?</div>
+            <div class="mt-1/2 button button--secondary pr-1/1 pl-1/1" data-role="load-more-posts" data-load-method="infinite-scroll" data-url="<%= request.original_url %>">An error occurred. Try again?</div>
           </div>
         `)
       }
@@ -25,7 +25,7 @@
       elements[elements.length - 1].insertAdjacentHTML("afterEnd", `
         <%= j render @posts %>
         <% if @posts.size == 20 %>
-          <div class="infinite-scroll" data-role="infinite-scroll-marker" data-url="<%= request.original_url %>"></div>
+          <div class="infinite-scroll" data-role="infinite-scroll-marker" data-load-method="infinite-scroll" data-url="<%= request.original_url %>"></div>
         <% else %>
           <h4 class="mt-1/2 mb-0"><center>You've reached the end.</center></h4>
         <% end %>

--- a/app/views/posts/infinite_scroll_posts.js.erb
+++ b/app/views/posts/infinite_scroll_posts.js.erb
@@ -1,5 +1,18 @@
 (() => {
-  <% if @posts.any? %>
+  <% if flash[:error].present? %>
+    <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
+      const elements = document.querySelectorAll("[data-role='infinite-scroll-marker']")
+
+      const button = document.querySelector("[data-role='load-more-posts']")
+      if (!button) {
+        elements[elements.length - 1].insertAdjacentHTML("afterEnd", `
+          <div class="flex justify-center">
+            <div class="mt-1/2 button button--secondary pr-1/1 pl-1/1" data-role="load-more-posts" data-url="<%= request.original_url %>">An error occurred. Try again?</div>
+          </div>
+        `)
+      }
+    <% end %>
+  <% elsif @posts.any? %>
     <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
       const elements = document.querySelectorAll("[data-role='infinite-scroll-marker']")
 

--- a/spec/system/forgot_passwords_spec.rb
+++ b/spec/system/forgot_passwords_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "ForgotPasswords", type: :system do
     end
   end
 
-  #TODO: Sad path of nonexistent or expired token or invalid email
+  # Sad path of nonexistent or expired token or invalid email
   describe "sad path: improper token" do
     context "which does not exist" do
       it "returns a 404" do


### PR DESCRIPTION
Previously, if Elasticsearch returned an error during search, it would fail silently. This PR explains the issue to the user and offers a retry option.

This button appears whenever Load More or Infinite Scroll fails to load more posts via Ajax:
![image](https://user-images.githubusercontent.com/10406383/165649536-cead8e49-c05c-4af2-943f-953dfe75c80b.png)

Pagination users will be given an error page:
![image](https://user-images.githubusercontent.com/10406383/165819809-1dfe87d2-7bcf-4e9f-8081-7ccaffc32aa7.png)


