### PR TITLE
User session cookie improvements

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,7 @@ class ApplicationController < ActionController::Base
     token = RememberToken.find_by_token(cookies.encrypted[:remember_token])
 
     if token && token.user
+      reset_session
       session[:user_id] = token.user.id
       session[:user_uuid] = token.user.uuid
       create_activity(:login_from_cookie)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,7 @@ class ApplicationController < ActionController::Base
 
     if token && token.user
       session[:user_id] = token.user.id
+      session[:user_uuid] = token.user.uuid
       create_activity(:login_from_cookie)
     end
   end
@@ -40,6 +41,12 @@ class ApplicationController < ActionController::Base
   def current_user
     if session[:user_id]
       @current_user ||= User.find_by(id: session[:user_id])
+
+      # Invalidate the session if a UUID is specified and the user's UUID does not match
+      if session[:user_uuid] && @current_user.uuid != session[:user_uuid]
+        reset_session
+        @current_user = nil
+      end
     else
       @current_user = nil
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,9 +26,11 @@ class ApplicationController < ActionController::Base
     token = RememberToken.find_by_token(cookies.encrypted[:remember_token])
 
     if token && token.user
+      redirect_to = session[:return_to]
       reset_session
       session[:user_id] = token.user.id
       session[:user_uuid] = token.user.uuid
+      session[:return_to] = redirect_to
       create_activity(:login_from_cookie)
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,11 +26,11 @@ class ApplicationController < ActionController::Base
     token = RememberToken.find_by_token(cookies.encrypted[:remember_token])
 
     if token && token.user
-      redirect_to = session[:return_to]
+      return_path = session[:return_to]
       reset_session
       session[:user_id] = token.user.id
       session[:user_uuid] = token.user.uuid
-      session[:return_to] = redirect_to
+      session[:return_to] = return_path
       create_activity(:login_from_cookie)
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,6 +51,7 @@ class ApplicationController < ActionController::Base
     else
       @current_user = nil
     end
+    @current_user
   end
 
   def set_current_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -32,6 +32,7 @@ class SessionsController < ApplicationController
 
       generate_remember_token if (params[:remember_me].present? && params[:remember_me] != "0") || (@user.provider.present?)
       session[:user_id] = @user.id
+      session[:user_uuid] = @user.uuid
 
       create_activity(:login, @user.id)
       ahoy.authenticate(@user)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,6 +30,7 @@ class SessionsController < ApplicationController
 
       reject_banned_user and return if is_banned?(@user)
 
+      reset_session
       generate_remember_token if (params[:remember_me].present? && params[:remember_me] != "0") || (@user.provider.present?)
       session[:user_id] = @user.id
       session[:user_uuid] = @user.uuid

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,10 +30,12 @@ class SessionsController < ApplicationController
 
       reject_banned_user and return if is_banned?(@user)
 
+      redirect_to = session[:return_to]
       reset_session
       generate_remember_token if (params[:remember_me].present? && params[:remember_me] != "0") || (@user.provider.present?)
       session[:user_id] = @user.id
       session[:user_uuid] = @user.uuid
+      session[:return_to] = redirect_to
 
       create_activity(:login, @user.id)
       ahoy.authenticate(@user)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,12 +30,12 @@ class SessionsController < ApplicationController
 
       reject_banned_user and return if is_banned?(@user)
 
-      redirect_to = session[:return_to]
+      return_path = session[:return_to]
       reset_session
       generate_remember_token if (params[:remember_me].present? && params[:remember_me] != "0") || (@user.provider.present?)
       session[:user_id] = @user.id
       session[:user_uuid] = @user.uuid
-      session[:return_to] = redirect_to
+      session[:return_to] = return_path
 
       create_activity(:login, @user.id)
       ahoy.authenticate(@user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,9 +66,12 @@ class User < ApplicationRecord
                             dimension: { max: 3500..3500 }
   validates :uuid, presence: true, uniqueness: true, length: { is: 36 }, format: { with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i }
 
-  before_validation do
-    self.uuid = SecureRandom.uuid unless self.uuid.present?
+  after_find do
+    # binding.pry
+    self.update_column(:uuid, SecureRandom.uuid) unless self.uuid.present?
   end
+
+  before_validation :generate_and_set_uuid, on: :create
 
   def self.find_or_create_from_auth_hash(auth_hash)
     uid = auth_hash["uid"]
@@ -96,5 +99,11 @@ class User < ApplicationRecord
 
   def clean_username
     self.username.split("#")[0]
+  end
+
+  private
+
+  def generate_and_set_uuid
+    self.uuid = SecureRandom.uuid
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,11 @@ class User < ApplicationRecord
   validates :banner_image, content_type: ["image/jpeg", "image/jpg", "image/png"],
                             size: { less_than: 2.megabytes },
                             dimension: { max: 3500..3500 }
+  validates :uuid, presence: true, uniqueness: true, length: { is: 36 }, format: { with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i }
+
+  before_validation do
+    self.uuid = SecureRandom.uuid unless self.uuid.present?
+  end
 
   def self.find_or_create_from_auth_hash(auth_hash)
     uid = auth_hash["uid"]

--- a/db/migrate/20220509180005_enable_uuid.rb
+++ b/db/migrate/20220509180005_enable_uuid.rb
@@ -1,5 +1,0 @@
-class EnableUuid < ActiveRecord::Migration[6.1]
-  def change
-    enable_extension 'pgcrypto' unless extensions.include? 'pgcrypto'
-  end
-end

--- a/db/migrate/20220509180005_enable_uuid.rb
+++ b/db/migrate/20220509180005_enable_uuid.rb
@@ -1,0 +1,5 @@
+class EnableUuid < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension 'pgcrypto' unless extensions.include? 'pgcrypto'
+  end
+end

--- a/db/migrate/20220509180158_add_uuid_to_models.rb
+++ b/db/migrate/20220509180158_add_uuid_to_models.rb
@@ -1,0 +1,8 @@
+require "securerandom"
+
+class AddUuidToModels < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :uuid, :uuid, default: "gen_random_uuid()"
+    add_index :users, :uuid, unique: true
+  end
+end

--- a/db/migrate/20220509180158_add_uuid_to_models.rb
+++ b/db/migrate/20220509180158_add_uuid_to_models.rb
@@ -1,8 +1,5 @@
-require "securerandom"
-
 class AddUuidToModels < ActiveRecord::Migration[6.1]
   def change
-    add_column :users, :uuid, :uuid, default: "gen_random_uuid()"
-    add_index :users, :uuid, unique: true
+    add_column :users, :uuid, :string, limit: 36, unique: true, default: ""
   end
 end

--- a/db/migrate/20220509180158_add_uuid_to_models.rb
+++ b/db/migrate/20220509180158_add_uuid_to_models.rb
@@ -1,5 +1,5 @@
 class AddUuidToModels < ActiveRecord::Migration[6.1]
   def change
-    add_column :users, :uuid, :string, limit: 36, unique: true, default: ""
+    add_column :users, :uuid, :string, limit: 36, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -289,6 +289,7 @@ ActiveRecord::Schema.define(version: 2022_04_21_201817) do
     t.text "custom_css"
     t.integer "pagination_type", default: 0
     t.integer "linked_id"
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }
     t.index ["email_bidx"], name: "index_users_on_email_bidx"
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_21_201817) do
+ActiveRecord::Schema.define(version: 2022_05_09_180158) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -289,7 +289,7 @@ ActiveRecord::Schema.define(version: 2022_04_21_201817) do
     t.text "custom_css"
     t.integer "pagination_type", default: 0
     t.integer "linked_id"
-    t.uuid "uuid", default: -> { "gen_random_uuid()" }
+    t.string "uuid", limit: 36, default: ""
     t.index ["email_bidx"], name: "index_users_on_email_bidx"
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -289,7 +289,7 @@ ActiveRecord::Schema.define(version: 2022_05_09_180158) do
     t.text "custom_css"
     t.integer "pagination_type", default: 0
     t.integer "linked_id"
-    t.string "uuid", limit: 36, default: ""
+    t.string "uuid", limit: 36
     t.index ["email_bidx"], name: "index_users_on_email_bidx"
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
This PR adds a UUID to the User model which is used to ensure that a session cannot incorrectly log a user into an account they do not own, which fixes #140. For user convenience, legacy sessions will continue to function.

This PR also includes a countermeasure to prevent [session fixation attacks](https://edgeguides.rubyonrails.org/security.html#session-fixation).
