### PR TITLE
feat: Favorites feed

### DIFF
--- a/app/assets/stylesheets/elements/_feed.scss
+++ b/app/assets/stylesheets/elements/_feed.scss
@@ -1,0 +1,62 @@
+.feed__item {
+  display: flex;
+  gap: $margin / 2;
+  padding: $margin / 2 0;
+  border-bottom: 1px solid $border-color;
+
+  .item__thumbnail {
+    display: block;
+  }
+}
+
+.feed__title {
+  margin: 0.35rem 0;
+}
+
+.feed__version {
+  margin-top: 0;
+  font-style: italic;
+}
+
+.feed__author {
+  margin: $margin / 4 0 0;
+  font-size: var(--font-size-small);
+
+  a {
+    color: $pure-white;
+    text-decoration: none;
+
+    @include hover-stack {
+      text-decoration: underline;
+    }
+  }
+}
+
+.feed__date {
+  margin: $margin / 8 0 0;
+  color: $text-color-dark;
+  font-size: var(--font-size-small);
+  font-style: italic;
+}
+
+.feed__update-notes {
+  margin-bottom: 0.5rem;
+}
+
+.feed__code {
+  height: auto;
+  width: 100%;
+  padding: $margin / 8 0;
+  margin: $margin / 8 0;
+  border-radius: $border-radius / 2;
+  font-size: 21px;
+
+  svg {
+    display: none;
+  }
+
+  .code__flag {
+    font-size: 0.65rem;
+    padding: 0.1rem 0.3rem;
+  }
+}

--- a/app/assets/stylesheets/elements/_feed.scss
+++ b/app/assets/stylesheets/elements/_feed.scss
@@ -2,15 +2,37 @@
   display: flex;
   gap: $margin / 2;
   padding: $margin / 2 0;
-  border-bottom: 1px solid $border-color;
+  border-top: 1px solid $border-color;
+
+  &--faded {
+    opacity: 0.75;
+  }
 
   .item__thumbnail {
     display: block;
   }
 }
 
+.feed__heading {
+  margin: 0 0 $margin / 2;
+  line-height: 1em;
+
+  .feed__item + & {
+    margin-top: $margin;
+  }
+}
+
 .feed__title {
   margin: 0.35rem 0;
+
+  a {
+    color: $white;
+    text-decoration: none;
+
+    &:hover {
+      color: $pure-white;
+    }
+  }
 }
 
 .feed__version {
@@ -23,11 +45,11 @@
   font-size: var(--font-size-small);
 
   a {
-    color: $pure-white;
+    color: $white;
     text-decoration: none;
 
     @include hover-stack {
-      text-decoration: underline;
+      color: $pure-white;
     }
   }
 }
@@ -59,4 +81,9 @@
     font-size: 0.65rem;
     padding: 0.1rem 0.3rem;
   }
+}
+
+.feed__message {
+  margin: 0 0 $margin / 2;
+  font-style: italic;
 }

--- a/app/assets/stylesheets/elements/_feed.scss
+++ b/app/assets/stylesheets/elements/_feed.scss
@@ -86,11 +86,11 @@
   width: 100%;
   padding: $margin / 8 0;
   border-radius: $border-radius / 2;
-  font-size: 21px;
 
   @include media-min(md) {
     height: auto;
     margin: $margin / 8 0;
+    font-size: 21px;
   }
 
   svg {

--- a/app/assets/stylesheets/elements/_feed.scss
+++ b/app/assets/stylesheets/elements/_feed.scss
@@ -1,12 +1,9 @@
 .feed__item {
-  display: flex;
+  display: grid;
+  grid-template-columns: $thumbnail-width auto;
   gap: $margin / 2;
   padding: $margin / 2 0;
   border-top: 1px solid $border-color;
-
-  &--faded {
-    opacity: 0.75;
-  }
 
   .item__thumbnail {
     display: block;
@@ -57,7 +54,7 @@
 .feed__date {
   margin: $margin / 8 0 0;
   color: $text-color-dark;
-  font-size: var(--font-size-small);
+  font-size: 0.75rem;
   font-style: italic;
 }
 

--- a/app/assets/stylesheets/elements/_feed.scss
+++ b/app/assets/stylesheets/elements/_feed.scss
@@ -1,12 +1,28 @@
 .feed__item {
-  display: grid;
-  grid-template-columns: $thumbnail-width auto;
-  gap: $margin / 2;
   padding: $margin / 2 0;
   border-top: 1px solid $border-color;
 
+  @include media-min(md) {
+    display: grid;
+    grid-template-columns: $thumbnail-width auto;
+    gap: $margin / 2;
+  }
+
   .item__thumbnail {
     display: block;
+  }
+}
+
+.feed__info {
+  display: grid;
+  grid-template: "thumbnail code" "author date";
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 0 $margin / 8;
+  margin-bottom: $margin / 2;
+
+  @include media-min(md) {
+    display: block;
+    margin: 0;
   }
 }
 
@@ -52,10 +68,14 @@
 }
 
 .feed__date {
-  margin: $margin / 8 0 0;
+  margin: $margin / 4 0 0;
   color: $text-color-dark;
   font-size: 0.75rem;
   font-style: italic;
+
+  @include media-min(md) {
+    margin: $margin / 8 0 0;
+  }
 }
 
 .feed__update-notes {
@@ -63,12 +83,15 @@
 }
 
 .feed__code {
-  height: auto;
   width: 100%;
   padding: $margin / 8 0;
-  margin: $margin / 8 0;
   border-radius: $border-radius / 2;
   font-size: 21px;
+
+  @include media-min(md) {
+    height: auto;
+    margin: $margin / 8 0;
+  }
 
   svg {
     display: none;

--- a/app/assets/stylesheets/elements/_profile.scss
+++ b/app/assets/stylesheets/elements/_profile.scss
@@ -16,8 +16,8 @@
 
 .profile__action {
   display: block;
-  margin: .5rem 0;
-  font-size: 21px;
+  margin: .25rem 0;
+  font-size: 18px;
   color: $text-color;
   text-decoration: none;
   font-family: "Barlow Condensed", "Impact";
@@ -26,6 +26,11 @@
 
   @include hover-stack {
     text-decoration: underline;
+  }
+
+  @include media-min(sm) {
+    margin: .5rem 0;
+    font-size: 21px;
   }
 
   &:first-of-type {

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,0 +1,10 @@
+class FeedController < ApplicationController
+  before_action do
+    redirect_to root_path unless current_user
+  end
+
+  def index
+    @favorite_ids = current_user.favorites.pluck(:post_id)
+    @revisions = Revision.where(post_id: @favorite_ids).order(created_at: :desc)
+  end
+end

--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -3,8 +3,20 @@ class FeedController < ApplicationController
     redirect_to root_path unless current_user
   end
 
+  after_action do
+    current_user.update(feed_last_visited_at: DateTime.now)
+  end
+
   def index
+    @feed_last_visited_at = current_user.feed_last_visited_at
+    @marker_shown = false
+
     @favorite_ids = current_user.favorites.pluck(:post_id)
-    @revisions = Revision.where(post_id: @favorite_ids).order(created_at: :desc)
+    @revisions = Revision.includes(:post).where(visible: true, post_id: @favorite_ids).order(created_at: :desc).page(params[:page])
+
+    respond_to do |format|
+      format.html
+      format.js { render "feed/infinite_scroll_feed_items" }
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,4 +75,20 @@ module ApplicationHelper
   def i18n_value_in_array(array, value)
     array.select { |item| item["en"].downcase == value&.downcase }[0]&.fetch(current_locale, nil)
   end
+
+  def user_menu_items
+    [
+      { title: t("account.navigation.overview"), url: account_path, data: { prefetch: false } },
+      { title: t("account.navigation.feed"), url: feed_index_path, data: { prefetch: false } },
+      { title: t("account.navigation.notifications"), url: notifications_path, },
+      { title: t("account.navigation.favorites"), url: account_favorites_path, },
+      { title: t("account.navigation.codes"), url: account_posts_path, },
+      { title: t("account.navigation.collections"), url: collections_path, },
+      { title: t("account.navigation.profile"), url: edit_profile_path, },
+      { title: t("account.navigation.account"), url: edit_user_path, },
+      { title: t("account.navigation.linked_users"), url: linked_users_path, },
+      { title: t("account.navigation.accessibility"), url: accessibility_path, },
+      { title: t("account.navigation.logout"), url: logout_path, data: { prefetch: false } }
+    ]
+  end
 end

--- a/app/views/application/_user_block.erb
+++ b/app/views/application/_user_block.erb
@@ -7,7 +7,8 @@
 
       <div class="dropdown__content lg-down:dropup" data-dropdown-content>
         <%= link_to t("account.navigation.overview"), account_path, class: "dropdown__item text-small", data: { prefetch: false } %>
-        <%= link_to t("account.navigation.notifications"), notifications_path, class: "dropdown__item text-small" %>
+        <%= link_to t("account.navigation.feed"), feed_index_path, class: "dropdown__item text-small", data: { prefetch: false }  %>
+        <%= link_to t("account.navigation.notifications"), notifications_path, class: "dropdown__item text-small", data: { prefetch: false }  %>
         <%= link_to t("account.navigation.favorites"), account_favorites_path, class: "dropdown__item text-small" %>
         <%= link_to t("account.navigation.codes"), account_posts_path, class: "dropdown__item text-small" %>
         <%= link_to t("account.navigation.collections"), collections_path, class: "dropdown__item text-small" %>

--- a/app/views/application/_user_block.erb
+++ b/app/views/application/_user_block.erb
@@ -6,25 +6,25 @@
       <%= link_to current_user.clean_username, account_path, class: "user-block__action mbl:mr-1/16 mb-1/4 mbl:mb-0", data: { action: "toggle-dropdown" } %>
 
       <div class="dropdown__content lg-down:dropup" data-dropdown-content>
-        <%= link_to t("account.navigation.overview"), account_path, class: "dropdown__item text-small", data: { prefetch: false } %>
-        <%= link_to t("account.navigation.feed"), feed_index_path, class: "dropdown__item text-small", data: { prefetch: false }  %>
-        <%= link_to t("account.navigation.notifications"), notifications_path, class: "dropdown__item text-small", data: { prefetch: false }  %>
-        <%= link_to t("account.navigation.favorites"), account_favorites_path, class: "dropdown__item text-small" %>
-        <%= link_to t("account.navigation.codes"), account_posts_path, class: "dropdown__item text-small" %>
-        <%= link_to t("account.navigation.collections"), collections_path, class: "dropdown__item text-small" %>
+        <% user_menu_items.each do |menu_item| %>
+          <%= link_to menu_item[:title],
+              menu_item[:url],
+              class: "dropdown__item text-small #{ "text-pure-white" if current_page?(menu_item[:url])}",
+              data: menu_item[:data] %>
 
-        <hr>
-
-        <%= link_to t("account.navigation.admin"), admin_root_path, class: "dropdown__item text-small", data: { prefetch: false } if is_admin?(current_user) %>
-        <%= link_to t("account.navigation.profile"), edit_profile_path, class: "dropdown__item text-small" %>
-        <%= link_to t("account.navigation.account"), edit_user_path, class: "dropdown__item text-small" %>
-        <%= link_to t("account.navigation.linked_users"), linked_users_path, class: "dropdown__item text-small" %>
-        <%= link_to t("account.navigation.accessibility"), accessibility_path, class: "dropdown__item text-small" %>
-        <%= link_to t("account.navigation.logout"), logout_path, class: "dropdown__item text-small", data: { prefetch: false } %>
+          <% if menu_item[:url] == collections_path %>
+            <hr>
+          <% end %>
+        <% end %>
 
         <hr>
 
         <%= link_to t("account.navigation.tos"), tos_path, class: "dropdown__item text-small" %>
+
+        <% if is_admin?(current_user) %>
+          <hr>
+          <%= link_to t("account.navigation.admin"), admin_root_path, data: { prefetch: false }, class: "dropdown__item text-small" %>
+        <% end %>
       </div>
     </div>
   <% else %>

--- a/app/views/feed/_feed_item.html.erb
+++ b/app/views/feed/_feed_item.html.erb
@@ -1,4 +1,4 @@
-<div class="feed__item">
+<div class="feed__item <%= "feed__item--faded" if @feed_last_visited_at && revision.created_at < @feed_last_visited_at %>">
   <div>
     <%= render "posts/thumbnail", post: revision.post %>
     <%= render "posts/code", post: revision.post, item_class: "code feed__code" %>
@@ -11,7 +11,10 @@
   </div>
 
   <div>
-    <h3 class="feed__title"><%= revision.post.title %></h3>
+    <h3 class="feed__title">
+      <%= link_to revision.post.title, post_path(revision.post.code) %>
+    </h3>
+
     <% if revision.version.present? %>
       <p class="feed__version"><%= revision.version %></p>
     <% end %>

--- a/app/views/feed/_feed_item.html.erb
+++ b/app/views/feed/_feed_item.html.erb
@@ -1,5 +1,5 @@
 <div class="feed__item">
-  <div>
+  <div class="feed__info">
     <%= render "posts/thumbnail", post: revision.post %>
     <%= render "posts/code", post: revision.post, item_class: "code feed__code" %>
 
@@ -20,7 +20,7 @@
     <% end %>
 
     <% if revision.description.blank? %>
-      <p>
+      <p class="mb-0">
         <em>No update notes provided.</em>
       </p>
     <% else %>

--- a/app/views/feed/_feed_item.html.erb
+++ b/app/views/feed/_feed_item.html.erb
@@ -1,0 +1,30 @@
+<div class="feed__item">
+  <div>
+    <%= render "posts/thumbnail", post: revision.post %>
+    <%= render "posts/code", post: revision.post, item_class: "code feed__code" %>
+
+    <p class="feed__author">
+      by <%= link_to revision.post.user.clean_username, user_profile_path(revision.post.user) %>
+    </p>
+
+    <p class="feed__date"><%= time_ago_in_words revision.created_at %> ago</p>
+  </div>
+
+  <div>
+    <h3 class="feed__title"><%= revision.post.title %></h3>
+    <% if revision.version.present? %>
+      <p class="feed__version"><%= revision.version %></p>
+    <% end %>
+
+    <% if revision.description.blank? %>
+      <p>
+        <em>No update notes provided.</em>
+      </p>
+    <% else %>
+      <h5 class="feed__update-notes">Update notes</h5>
+      <div class="item__description mt-1/8">
+        <%= sanitized_markdown(revision.description) %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/feed/_feed_item.html.erb
+++ b/app/views/feed/_feed_item.html.erb
@@ -1,4 +1,4 @@
-<div class="feed__item <%= "feed__item--faded" if @feed_last_visited_at && revision.created_at < @feed_last_visited_at %>">
+<div class="feed__item">
   <div>
     <%= render "posts/thumbnail", post: revision.post %>
     <%= render "posts/code", post: revision.post, item_class: "code feed__code" %>

--- a/app/views/feed/_feed_items.html.erb
+++ b/app/views/feed/_feed_items.html.erb
@@ -1,10 +1,10 @@
 <div class="items mt-0">
-  <% if @revisions.any? %>
+  <% if @revisions.present? %>
     <% @revisions.each do |revision| %>
       <% if !@marker_shown && @feed_last_visited_at && revision.created_at < @feed_last_visited_at %>
         <% @marker_shown = true %>
 
-        <h2 class="feed__heading">Already seen updates</h2>
+        <h2 class="feed__heading">Seen updates</h2>
       <% end %>
 
       <%= render "feed_item", revision: revision %>
@@ -12,13 +12,13 @@
 
     <% if @revisions.count == 20 %>
       <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
-        <div class="infinite-scroll" data-role="infinite-scroll-marker" data-url="<%= request.original_url %>"></div>
+        <div class="infinite-scroll" data-role="infinite-scroll-marker" data-url="<%= request.original_url %>" data-load-method="infinite-scroll"></div>
       <% end %>
 
       <% if current_user && current_user.pagination_type == "load_more" %>
         <div data-role="load-more-posts-marker"></div>
         <div class="flex justify-center">
-          <div class="mt-1/2 button button--secondary pr-1/1 pl-1/1" data-role="load-more-posts" data-url="<%= request.original_url %>">Load more</div>
+          <div class="mt-1/2 button button--secondary pr-1/1 pl-1/1" data-role="load-more-posts" data-url="<%= request.original_url %>" data-load-method="load-more-button">Load more</div>
         </div>
       <% end %>
     <% end %>

--- a/app/views/feed/_feed_items.html.erb
+++ b/app/views/feed/_feed_items.html.erb
@@ -1,0 +1,30 @@
+<div class="items mt-0">
+  <% if @revisions.any? %>
+    <% @revisions.each do |revision| %>
+      <% if !@marker_shown && @feed_last_visited_at && revision.created_at < @feed_last_visited_at %>
+        <% @marker_shown = true %>
+
+        <h2 class="feed__heading">Already seen updates</h2>
+      <% end %>
+
+      <%= render "feed_item", revision: revision %>
+    <% end %>
+
+    <% if @revisions.count == 20 %>
+      <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
+        <div class="infinite-scroll" data-role="infinite-scroll-marker" data-url="<%= request.original_url %>"></div>
+      <% end %>
+
+      <% if current_user && current_user.pagination_type == "load_more" %>
+        <div data-role="load-more-posts-marker"></div>
+        <div class="flex justify-center">
+          <div class="mt-1/2 button button--secondary pr-1/1 pl-1/1" data-role="load-more-posts" data-url="<%= request.original_url %>">Load more</div>
+        </div>
+      <% end %>
+    <% end %>
+  <% else %>
+    <p>No results</p>
+  <% end %>
+</div>
+
+<%= paginate @revisions if current_user && current_user.pagination_type == "pagination" %>

--- a/app/views/feed/index.html.erb
+++ b/app/views/feed/index.html.erb
@@ -2,14 +2,14 @@
   <% if current_user.favorites.any? %>
     <h2 class="feed__heading">New updates</h2>
 
-    <% if @feed_last_visited_at && @revisions.first.created_at < @feed_last_visited_at %>
-      <p class="feed__message">There are no new updates since your last visit, which was <%= time_ago_in_words(@feed_last_visited_at) %> ago.</p>
+    <% if @feed_last_visited_at && (@revisions&.first.blank? || @revisions.first.created_at < @feed_last_visited_at) %>
+      <p class="feed__message">No new updates since your last visit, which was <%= time_ago_in_words(@feed_last_visited_at) %> ago.</p>
     <% end %>
 
     <%= render "feed_items" %>
   <% else %>
     <p class="feed__message">
-      This is where we would show updates to your favorited codes, if you had any.
+      Updates to posts you favorite will show up here. Go favorite some modes!
     </p>
   <% end %>
 <% end %>

--- a/app/views/feed/index.html.erb
+++ b/app/views/feed/index.html.erb
@@ -1,16 +1,15 @@
 <%= render "layouts/account", title: t("account.navigation.feed") do %>
   <% if current_user.favorites.any? %>
+    <h2 class="feed__heading">New updates</h2>
+
     <% if @feed_last_visited_at && @revisions.first.created_at < @feed_last_visited_at %>
       <p class="feed__message">There are no new updates since your last visit, which was <%= time_ago_in_words(@feed_last_visited_at) %> ago.</p>
-    <% else %>
-      <h2 class="feed__heading">New updates</h2>
     <% end %>
 
     <%= render "feed_items" %>
   <% else %>
     <p class="feed__message">
-      This is where we would show updates to your favorited codes, if you had any. <br>
-      <span class="text-white">Start favorting codes and follow there updates!</span>
+      This is where we would show updates to your favorited codes, if you had any.
     </p>
   <% end %>
 <% end %>

--- a/app/views/feed/index.html.erb
+++ b/app/views/feed/index.html.erb
@@ -1,5 +1,16 @@
 <%= render "layouts/account", title: t("account.navigation.feed") do %>
-  <% @revisions.each do |revision| %>
-    <%= render "feed_item", revision: revision %>
+  <% if current_user.favorites.any? %>
+    <% if @feed_last_visited_at && @revisions.first.created_at < @feed_last_visited_at %>
+      <p class="feed__message">There are no new updates since your last visit, which was <%= time_ago_in_words(@feed_last_visited_at) %> ago.</p>
+    <% else %>
+      <h2 class="feed__heading">New updates</h2>
+    <% end %>
+
+    <%= render "feed_items" %>
+  <% else %>
+    <p class="feed__message">
+      This is where we would show updates to your favorited codes, if you had any. <br>
+      <span class="text-white">Start favorting codes and follow there updates!</span>
+    </p>
   <% end %>
 <% end %>

--- a/app/views/feed/index.html.erb
+++ b/app/views/feed/index.html.erb
@@ -1,0 +1,5 @@
+<%= render "layouts/account", title: t("account.navigation.feed") do %>
+  <% @revisions.each do |revision| %>
+    <%= render "feed_item", revision: revision %>
+  <% end %>
+<% end %>

--- a/app/views/feed/infinite_scroll_feed_items.js.erb
+++ b/app/views/feed/infinite_scroll_feed_items.js.erb
@@ -1,0 +1,32 @@
+(() => {
+  <% if @revisions.any? %>
+    <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
+      const elements = document.querySelectorAll("[data-role='infinite-scroll-marker']")
+
+      elements[elements.length - 1].insertAdjacentHTML("afterEnd", `
+        <%= j render "feed_items" %>
+        <% if @revisions.count == 20 %>
+          <div class="infinite-scroll" data-role="infinite-scroll-marker" data-url="<%= request.original_url %>"></div>
+        <% else %>
+          <h4 class="mt-1/2 mb-0"><center>You've reached the end.</center></h4>
+        <% end %>
+      `)
+    <% end %>
+
+    <% if current_user && current_user.pagination_type == "load_more" %>
+      const button = document.querySelector("[data-role='load-more-posts']")
+      const marker = document.querySelector("[data-role='load-more-posts-marker']")
+
+      marker.insertAdjacentHTML("beforeBegin", `
+        <%= j render "feed_items" %>
+        <% if @revisions.count < 20 %>
+          <h4 class="mt-1/2 mb-0"><center>You've reached the end.</center></h4>
+        <% end %>
+      `)
+
+      <% if @revisions.count < 20 %>
+        button.remove()
+      <% end %>
+    <% end %>
+  <% end %>
+})()

--- a/app/views/feed/infinite_scroll_feed_items.js.erb
+++ b/app/views/feed/infinite_scroll_feed_items.js.erb
@@ -1,5 +1,14 @@
 (() => {
-  <% if @revisions.any? %>
+  <% if @error.present? %>
+    <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
+      const elements = document.querySelectorAll("[data-role='infinite-scroll-marker']")
+
+      const button = document.querySelector("[data-role='load-more-posts']")
+      if (!button) {
+        elements[elements.length - 1].insertAdjacentHTML("afterEnd", '<center class="mt-1/2 text-red"><%= @error %></center>')
+      }
+    <% end %>
+  <% elsif @revisions.any? %>
     <% unless current_user && current_user.pagination_type != "infinite_scroll" %>
       const elements = document.querySelectorAll("[data-role='infinite-scroll-marker']")
 

--- a/app/views/layouts/_account.html.erb
+++ b/app/views/layouts/_account.html.erb
@@ -1,24 +1,27 @@
 <div class="heading">
+  <div class="hidden-sm mb-1/1">
+    <select onchange="location = this.value" class="form-select">
+      <% user_menu_items.each do |menu_item| %>
+        <option value=<%= menu_item[:url] %> <%= "selected" if current_page?(menu_item[:url]) %>><%= menu_item[:title] %></option>
+      <% end %>
+    </select>
+  </div>
+
   <h1 class="text-md-center text-pure-white"><%= title.html_safe %></h1>
 </div>
 
 <div class="profile">
-  <aside>
-    <%= link_to t("account.navigation.overview"), account_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_path) }", data: { prefetch: false }  %>
-    <%= link_to t("account.navigation.feed"), feed_index_path, class: "profile__action #{ 'profile__action--active' if current_page?(feed_index_path) }", data: { prefetch: false }  %>
-    <%= link_to t("account.navigation.notifications"), notifications_path, class: "profile__action #{ 'profile__action--active' if current_page?(notifications_path) }", data: { prefetch: false }  %>
-    <%= link_to t("account.navigation.favorites"), account_favorites_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_favorites_path) }" %>
-    <%= link_to t("account.navigation.codes"), account_posts_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_posts_path) }" %>
-    <%= link_to t("account.navigation.collections"), collections_path, class: "profile__action #{ 'profile__action--active' if current_page?(collections_path) }" %>
+  <aside class="hidden visible-sm">
+    <% user_menu_items.each do |menu_item| %>
+      <%= link_to menu_item[:title],
+          menu_item[:url],
+          class: "profile__action #{ "profile__action--active" if current_page?(menu_item[:url]) }",
+          data: menu_item[:data] %>
 
-    <hr class="mt-1/2 mb-1/2">
-
-    <%= link_to t("account.navigation.admin"), admin_root_path, class: "profile__action", data: { prefetch: false }  if current_user.level == "admin" %>
-    <%= link_to t("account.navigation.profile"), edit_profile_path, class: "profile__action #{ 'profile__action--active' if current_page?(edit_profile_path) }" %>
-    <%= link_to t("account.navigation.account"), edit_user_path, class: "profile__action #{ 'profile__action--active' if current_page?(edit_user_path) }" %>
-    <%= link_to t("account.navigation.linked_users"), linked_users_path, class: "profile__action #{ 'profile__action--active' if current_page?(linked_users_path) }" %>
-    <%= link_to t("account.navigation.accessibility"), accessibility_path, class: "profile__action #{ 'profile__action--active' if current_page?(accessibility_path) }" %>
-    <%= link_to t("account.navigation.logout"), logout_path, class: "profile__action", data: { prefetch: false }  %>
+      <% if menu_item[:url] == collections_path %>
+        <hr class="mt-1/2 mb-1/2">
+      <% end %>
+    <% end %>
   </aside>
 
   <main>

--- a/app/views/layouts/_account.html.erb
+++ b/app/views/layouts/_account.html.erb
@@ -5,6 +5,7 @@
 <div class="profile">
   <aside>
     <%= link_to t("account.navigation.overview"), account_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_path) }" %>
+    <%= link_to t("account.navigation.feed"), feed_index_path, class: "profile__action #{ 'profile__action--active' if current_page?(feed_index_path) }" %>
     <%= link_to t("account.navigation.notifications"), notifications_path, class: "profile__action #{ 'profile__action--active' if current_page?(notifications_path) }" %>
     <%= link_to t("account.navigation.favorites"), account_favorites_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_favorites_path) }" %>
     <%= link_to t("account.navigation.codes"), account_posts_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_posts_path) }" %>

--- a/app/views/layouts/_account.html.erb
+++ b/app/views/layouts/_account.html.erb
@@ -4,21 +4,21 @@
 
 <div class="profile">
   <aside>
-    <%= link_to t("account.navigation.overview"), account_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_path) }" %>
-    <%= link_to t("account.navigation.feed"), feed_index_path, class: "profile__action #{ 'profile__action--active' if current_page?(feed_index_path) }" %>
-    <%= link_to t("account.navigation.notifications"), notifications_path, class: "profile__action #{ 'profile__action--active' if current_page?(notifications_path) }" %>
+    <%= link_to t("account.navigation.overview"), account_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_path) }", data: { prefetch: false }  %>
+    <%= link_to t("account.navigation.feed"), feed_index_path, class: "profile__action #{ 'profile__action--active' if current_page?(feed_index_path) }", data: { prefetch: false }  %>
+    <%= link_to t("account.navigation.notifications"), notifications_path, class: "profile__action #{ 'profile__action--active' if current_page?(notifications_path) }", data: { prefetch: false }  %>
     <%= link_to t("account.navigation.favorites"), account_favorites_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_favorites_path) }" %>
     <%= link_to t("account.navigation.codes"), account_posts_path, class: "profile__action #{ 'profile__action--active' if current_page?(account_posts_path) }" %>
     <%= link_to t("account.navigation.collections"), collections_path, class: "profile__action #{ 'profile__action--active' if current_page?(collections_path) }" %>
 
     <hr class="mt-1/2 mb-1/2">
 
-    <%= link_to t("account.navigation.admin"), admin_root_path, class: "profile__action" if current_user.level == "admin" %>
+    <%= link_to t("account.navigation.admin"), admin_root_path, class: "profile__action", data: { prefetch: false }  if current_user.level == "admin" %>
     <%= link_to t("account.navigation.profile"), edit_profile_path, class: "profile__action #{ 'profile__action--active' if current_page?(edit_profile_path) }" %>
     <%= link_to t("account.navigation.account"), edit_user_path, class: "profile__action #{ 'profile__action--active' if current_page?(edit_user_path) }" %>
     <%= link_to t("account.navigation.linked_users"), linked_users_path, class: "profile__action #{ 'profile__action--active' if current_page?(linked_users_path) }" %>
     <%= link_to t("account.navigation.accessibility"), accessibility_path, class: "profile__action #{ 'profile__action--active' if current_page?(accessibility_path) }" %>
-    <%= link_to t("account.navigation.logout"), logout_path, class: "profile__action" %>
+    <%= link_to t("account.navigation.logout"), logout_path, class: "profile__action", data: { prefetch: false }  %>
   </aside>
 
   <main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -345,6 +345,7 @@ en:
       accessibility: Accessibility
       logout: Logout
       linked_users: Linked Accounts
+      feed: Update Feed
     listings:
       title: Listings in the last 60 minutes
       path: Path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,8 @@ Rails.application.routes.draw do
     get "forgot-password/:token", to: "forgot_passwords#show", as: "forgot_password"
     post "reset_password", to: "forgot_passwords#reset_password", as: "reset_password"
 
+    resources :feed, only: [:index]
+
     resources :linked_users, only: [:index]
     # For some reason this cannot be merged into the above resources.
     # See https://github.com/EloHellEsports/workshop.codes/pull/123#discussion_r827509566

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,7 +92,7 @@ Rails.application.routes.draw do
     get "forgot-password/:token", to: "forgot_passwords#show", as: "forgot_password"
     post "reset_password", to: "forgot_passwords#reset_password", as: "reset_password"
 
-    resources :feed, only: [:index]
+    resources :feed, concerns: :paginatable, only: [:index]
 
     resources :linked_users, only: [:index]
     # For some reason this cannot be merged into the above resources.

--- a/db/migrate/20220508135642_add_feed_last_visisted_at_to_users.rb
+++ b/db/migrate/20220508135642_add_feed_last_visisted_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddFeedLastVisistedAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :feed_last_visited_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_21_201817) do
+ActiveRecord::Schema.define(version: 2022_05_08_135642) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -289,6 +289,7 @@ ActiveRecord::Schema.define(version: 2022_04_21_201817) do
     t.text "custom_css"
     t.integer "pagination_type", default: 0
     t.integer "linked_id"
+    t.datetime "feed_last_visited_at"
     t.index ["email_bidx"], name: "index_users_on_email_bidx"
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_08_135642) do
+ActiveRecord::Schema.define(version: 2022_05_09_180158) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -290,6 +290,7 @@ ActiveRecord::Schema.define(version: 2022_05_08_135642) do
     t.integer "pagination_type", default: 0
     t.integer "linked_id"
     t.datetime "feed_last_visited_at"
+    t.string "uuid", limit: 36
     t.index ["email_bidx"], name: "index_users_on_email_bidx"
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
This PR adds a feed to the account pages that shows updates to modes you have favorited. This is the first step to added a more interactive feed, in the future I hope to add more things such as comments placed, recommendations based on your favorites, users you might be interested in, etc.

When you visit the feed a field is updated on the user model that tracks when you last visited the feed. This was in favor of a cookie since that wouldn't work across different browsers/devices.

With this also comes a bit of a redesign for the menu on the account pages on mobile. Before the menu took up the entire screen and it was hard to navigate as a result. I've replaced it with a select field that navigates on change. For this I refactored the user user items in to a single object, making it a bit easier to use in different places.

Closes #147 

| Desktop | Mobile |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/12848235/168376526-9e91a1fe-db6c-4f40-870d-4f521a5eac5a.png) | ![image](https://user-images.githubusercontent.com/12848235/168376545-f5aa3904-7aa3-4d8e-b1ab-08097aa694bf.png) |

## When there's no new updates
![image](https://user-images.githubusercontent.com/12848235/168376997-75e74a2d-b05d-4ef9-8170-794a7e266c60.png)

## When you have no favorites
![image](https://user-images.githubusercontent.com/12848235/168377096-2cb783ee-e3f3-4c85-9bfe-7fffd2295cda.png)
