### PR TITLE
feat: Update post analytics with impressions count

### DIFF
--- a/app/assets/stylesheets/elements/_card.scss
+++ b/app/assets/stylesheets/elements/_card.scss
@@ -15,6 +15,10 @@
     grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   }
 
+  &--fit {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
   &--on-fire {
     display: grid;
     grid-template-columns: repeat(30, 100%);
@@ -138,7 +142,9 @@
 }
 
 .card__title {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
   padding-bottom: .5rem;
   margin-bottom: auto;
   font-family: $font-stack;

--- a/app/assets/stylesheets/utilities/_display.scss
+++ b/app/assets/stylesheets/utilities/_display.scss
@@ -41,3 +41,7 @@
   opacity: 0;
   transition: opacity 500ms ease-out;
 }
+
+.overflow-visible {
+  overflow: visible;
+}

--- a/app/views/posts/_analytics.html.erb
+++ b/app/views/posts/_analytics.html.erb
@@ -1,18 +1,51 @@
-<div class="favorite favorite--is-active ml-0 mt-1/2">
-  <%= image_tag "icons/icon-heart.svg", style: "height: 16px" %>
-  <span class="favorite__label"><%= post.favorites_count %></span>
-</div>
+<div class="cards cards--fit mt-1/4">
+  <div class="card">
+    <span class="card__title">
+      <%= image_tag "icons/icon-heart.svg", height: 16 %>
+      Total favorites
+    </span>
 
-<% if post.hotness %>
-  <div class="tooltip align-center ml-0">
-    <%= inline_svg_tag "icons/icon-onfire.svg", height: 16, width: 16 %>
-    <span class="favorite__label"><%= post.hotness %></span>
-
-    <div class="tooltip__content">
-      <strong>On Fire score</strong> This value is an indicator of how popular a code is at the moment. Higher = better.
-    </div>
+    <big><%= post.favorites_count %></big>
   </div>
-<% end %>
+
+  <div class="card overflow-visible">
+    <span class="card__title">
+      <%= inline_svg_tag "icons/icon-views.svg", height: 16, width: 16, class: "fill-current-color" %>
+
+      <div class="flex">
+        Total views
+
+        <em class="tooltip align-center ml-1/8 text-base text-small">
+          (?)
+          <div class="tooltip__content">
+            Updates daily
+          </div>
+        </em>
+      </div>
+    </span>
+
+    <big><%= post.impressions_count %></big>
+  </div>
+
+  <div class="card overflow-visible">
+    <span class="card__title">
+      <%= inline_svg_tag "icons/icon-onfire.svg", height: 16, width: 16 %>
+
+      <div class="flex">
+        On Fire
+
+        <em class="tooltip align-center ml-1/8 text-base text-small">
+          (?)
+          <div class="tooltip__content">
+            This value is an indicator of how popular a code is at the moment. Higher = better.
+          </div>
+        </em>
+      </div>
+    </span>
+
+    <big><%= post.hotness %></big>
+  </div>
+</div>
 
 <div data-post-analytics data-reveal-by-select-parent class="mt-1/2">
   <label class="form-label">Analytics type</label>


### PR DESCRIPTION
This PR adds the total impressions count to post analytics. It also adds cards similar to the analytics on the user overview page. I also wanted to add total copies count but we don't have a cache counter for that yet so I will leave that for a separate PR.

## User posts page
| Desktop | Mobile |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/12848235/171997851-25d8685a-73cd-4f28-b0d9-5de7049e2e82.png) |  ![image](https://user-images.githubusercontent.com/12848235/171997887-137c3a01-7a0a-416d-93d1-5fb69f93dc41.png) |


## Analytics on post show
![image](https://user-images.githubusercontent.com/12848235/171997863-ec136626-24cf-4eb8-bbd5-6093036b308c.png)
