### PR TITLE
feat: Scroll anchor for comment notifications

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,7 +15,7 @@ class CommentsController < ApplicationController
         if @comment.user != parent_comment_user
           create_notification(
             "Someone **has replied** to your comment on **\"==#{ @comment.post.title }==\"**",
-            post_tab_path(@comment.post.code, "comments"),
+            post_tab_path(@comment.post.code, "comments", anchor: @comment.id),
             parent_comment_user.id,
             :comment_reply,
             "comment",
@@ -26,7 +26,7 @@ class CommentsController < ApplicationController
         if @comment.user != @comment.post.user
           create_notification(
             "Someone **has left a comment** on **\"==#{ @comment.post.title }==\"**",
-            post_tab_path(@comment.post.code, "comments"),
+            post_tab_path(@comment.post.code, "comments", anchor: @comment.id),
             @comment.post.user.id,
             :comment,
             "comment",

--- a/app/javascript/src/get-partial.js
+++ b/app/javascript/src/get-partial.js
@@ -34,7 +34,26 @@ function getPartial(event, element) {
 
   new FetchRails(url).get()
     .then(data => {
-      targetElement.dataset.loaded = "true"
       targetElement.innerHTML = data
+    })
+    .then(() => {
+      if (_this.dataset.scrollOnLoad != "true") return
+
+      const hash = window.location.hash?.substring(1)
+      if (!hash) return
+
+      const scrollElement = document.getElementById(hash)
+      if (!scrollElement) return
+
+      const scrollOffset = scrollElement.getBoundingClientRect().top + document.documentElement.scrollTop
+
+      window.scrollTo({ top: scrollOffset - 70, behavior: "smooth" })
+    })
+    .catch(error => {
+      console.error(error)
+      targetElement.innerHTML = `<em>Something went wrong when loading, please try again. (${ error })</em>`
+    })
+    .finally(() => {
+      targetElement.dataset.loaded = "true"
     })
 }

--- a/app/javascript/src/get-partial.js
+++ b/app/javascript/src/get-partial.js
@@ -46,8 +46,10 @@ function getPartial(event, element) {
       if (!scrollElement) return
 
       const scrollOffset = scrollElement.getBoundingClientRect().top + document.documentElement.scrollTop
+      const stickyElement = document.querySelector("[data-role~='sticky']")
+      const scrollExtra = stickyElement ? stickyElement.offsetHeight * 1.25 : 0
 
-      window.scrollTo({ top: scrollOffset - 70, behavior: "smooth" })
+      window.scrollTo({ top: scrollOffset - scrollExtra, behavior: "smooth" })
     })
     .catch(error => {
       console.error(error)

--- a/app/views/posts/_tabs.html.erb
+++ b/app/views/posts/_tabs.html.erb
@@ -25,7 +25,7 @@
 
     <%= link_to post_tab_path(@post.code, "comments"),
                 class: "tabs__item #{ "tabs__item--active" if is_active_tab?("comments") }",
-                data: { action: "set-tab get-partial", target: "comments", url: comment_path(@post.id), get_on_load: is_active_tab?("comments") } do %>
+                data: { action: "set-tab get-partial", target: "comments", url: comment_path(@post.id), get_on_load: is_active_tab?("comments"), scroll_on_load: true } do %>
 
       <%= t("posts.show.tabs.comments") %>
       <small data-role="comment-total" class="text-dark"><%= @post.comments_count %></small>


### PR DESCRIPTION
This PR adds a scroll anchor to comment notifications so it scrolls to the correct comment on load. Since the comments are loaded async this required adjusting the `getPartial` function to scroll after loading. The added benefit of this is that the scroll is smooth rather than instant, which looks neat. I've also refactored parts of this function to catch errors and show them, just in case.