### PR TITLE
style: Fix incorrect styling of tables in editor

### DIFF
--- a/app/assets/stylesheets/logged_in_user/_inscryb-mde.scss
+++ b/app/assets/stylesheets/logged_in_user/_inscryb-mde.scss
@@ -112,6 +112,14 @@
   }
 }
 
+.editor-preview table td,
+.editor-preview table th,
+.editor-preview-side table td,
+.editor-preview-side table th {
+  border: 0;
+  padding: .5rem;
+}
+
 .fa-bold::before {
   content: "B";
   font-weight: bold;


### PR DESCRIPTION
The editor was incorrectly applying some of it's own styling. With this PR that styling is overwritten.

## Before
![image](https://user-images.githubusercontent.com/12848235/173896245-c7c6b97b-9d27-4c50-b17b-a375e0a91139.png)
## After
![image](https://user-images.githubusercontent.com/12848235/173896207-d61076a8-daf2-476d-a8bf-794f78bd88d8.png)
