### PR TITLE
feat: Add image previews to dropzone

### DIFF
--- a/app/assets/stylesheets/logged_in_user/_images-preview.scss
+++ b/app/assets/stylesheets/logged_in_user/_images-preview.scss
@@ -15,9 +15,15 @@
   cursor: grab;
   color: $body-bg;
 
+  @include hover-stack {
+    filter: brightness(1.1);
+    box-shadow: 0 0 0 2px $white;
+  }
+
   &:active {
     cursor: grabbing;
   }
+
 
   img,
   svg {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,6 +75,8 @@ class ApplicationController < ActionController::Base
     if image.present?
       if params[:type] == "thumbnail"
         url = rails_public_blob_url(image.variant(quality: 95, resize_to_fill: [200, 200 / 9 * 5], format: :webp).processed)
+      elsif params[:type] == "full"
+        url = rails_public_blob_url(image.variant(quality: 95).processed)
       else
         url = rails_public_blob_url(image.variant(quality: 95, resize_to_limit: [1920, 1080], format: :webp).processed)
       end

--- a/app/javascript/src/components/form/Dropzone.svelte
+++ b/app/javascript/src/components/form/Dropzone.svelte
@@ -80,7 +80,7 @@
       const randomId = Math.random().toString(36).substr(2, 9)
       images = [...images, { id: randomId, type: "preview" }]
 
-      const interval = setInterval(async () => {
+      const interval = setInterval(async() => {
         setProgress(randomId, uploader.progress)
 
         if (!uploader.blob) return

--- a/app/javascript/src/components/form/Dropzone.svelte
+++ b/app/javascript/src/components/form/Dropzone.svelte
@@ -19,7 +19,8 @@
   let sortable
   let active = false
   let alert = ""
-  
+  let previewImageUrl = ""
+
   const imagePreviewWidth = 200
 
   $: if (alert) setTimeout(() => { alert = "" }, 3000)
@@ -65,7 +66,6 @@
       if (file.kind == "file") file = file.getAsFile()
 
       if (file.type == "image/png" || file.type == "image/jpg" || file.type == "image/jpeg") {
-        console.log(file)
         uploadImage(file)
       } else {
         alert = "Wrong file type. Only png and jpeg are accepted."
@@ -75,12 +75,12 @@
 
   function uploadImage(image) {
     const uploader = new Uploader(image, input)
-    
+
     uploader.upload().then(() => {
       const randomId = Math.random().toString(36).substr(2, 9)
       images = [...images, { id: randomId, type: "preview" }]
 
-      const interval = setInterval(() => {
+      const interval = setInterval(async () => {
         setProgress(randomId, uploader.progress)
 
         if (!uploader.blob) return
@@ -88,13 +88,18 @@
 
         clearInterval(interval)
 
-        new FetchRails(`/active_storage_blob_variant_url/${ uploader.blob.key }?type=thumbnail`)
-          .get()
-          .then(data => setImage(randomId, uploader.blob.id, data))
-          .catch(() => alert = "Something went wrong when retrieving your image")
+        try {
+          const [thumbnail, preview] = await Promise.all([
+            new FetchRails(`/active_storage_blob_variant_url/${ uploader.blob.key }?type=thumbnail`).get(),
+            new FetchRails(`/active_storage_blob_variant_url/${ uploader.blob.key }?type=full`).get()
+          ])
+
+          setImage(randomId, uploader.blob.id, thumbnail, preview)
+        } catch (error) {
+          alert = "Something went wrong when retrieving your image"
+        }
       }, 100)
-    })
-      .catch(error => alert = error)
+    }).catch(error => alert = error)
   }
 
   function setProgress(id, progress) {
@@ -105,11 +110,11 @@
     })
   }
 
-  function setImage(id, blobId, url) {
+  function setImage(id, blobId, thumbnail, preview) {
     images = images.map(i => {
       if (i.id != id) return i
 
-      return { id: blobId, url }
+      return { id: blobId, url: thumbnail, preview_url: preview }
     })
   }
 
@@ -119,6 +124,8 @@
 </script>
 
 
+
+<svelte:window on:keydown={event => { if (event.key === "Escape") previewImageUrl = "" }} />
 
 <div
   class="dropzone"
@@ -149,22 +156,40 @@
       data-id={ image.id }
       transition:fade={{ duration: 200 }}
       animate:flip={{ duration: 200 }}>
-      
+
       { #if image.type == "preview" }
         <div class="images-preview__progress">
           <div class="images-preview__progress-bar" style="width: { image.progress }%" />
         </div>
       { :else }
-        <img src={ image.url } height={ imagePreviewWidth / 9 * 5 } width={ imagePreviewWidth } alt="Dropzone preview" />
+        <img
+          on:click={ () => previewImageUrl = image.preview_url }
+          src={ image.url }
+          height={ imagePreviewWidth / 9 * 5 }
+          width={ imagePreviewWidth }
+          alt="" />
       { /if }
 
-      <div class="images-preview__action" on:click={ () => removeImage(image.id) }>X</div>
+      <div class="images-preview__action" on:click|stopPropagation={ () => removeImage(image.id) }>X</div>
     </div>
   { /each }
 </div>
 
 { #if alert }
-  <div class="alert alert--error">
-    { alert }
+  <div class="alerts">
+    <div class="alerts__alert alerts__alert--error">
+      { alert }
+    </div>
+  </div>
+{ /if }
+
+{ #if previewImageUrl }
+  <div class="modal modal--auto" transition:fade={{ duration: 100 }} on:click={() => previewImageUrl = ""} data-hide-on-close>
+
+    <div class="modal__content p-0">
+      <img class="img-fluid" src={previewImageUrl} alt="" />
+    </div>
+
+    <div class="modal__backdrop" />
   </div>
 { /if }

--- a/app/views/posts/form/_image_upload.html.erb
+++ b/app/views/posts/form/_image_upload.html.erb
@@ -3,7 +3,11 @@
   <%= form.hidden_field :image_order %>
 
   <%= svelte_component("Dropzone", {
-        images: (@ordered_images || {}).map { |i| { id: i.blob_id, url: rails_public_blob_url(i.variant(quality: 95, resize_to_fill: [200, 200 / 9 * 5]).processed) } },
+        images: (@ordered_images || {}).map { |i| {
+          id: i.blob_id,
+          url: rails_public_blob_url(i.variant(quality: 95, resize_to_fill: [200, 200 / 9 * 5]).processed),
+          preview_url: rails_public_blob_url(i.variant(quality: 95).processed)
+        } },
         label: t("posts.form.images.dropzone.label"),
         help: t("posts.form.images.dropzone.help"),
         button: "Browse files on device",


### PR DESCRIPTION
This PR adds the option to click on images in the dropzone to display them fullscreen, like you would in the carousel if you click "view original size". The modal is a bit of a mash between svelte and regular js. I would like to refactor the modal to be fully Svelte at some point, but that's for another PR.

![image](https://user-images.githubusercontent.com/12848235/173908414-837dde51-f839-4cab-a08a-d5f2b9dfc1b5.png)
![image](https://user-images.githubusercontent.com/12848235/173908429-e2cf6d7c-5e99-43d9-a000-fdbd48890c1e.png)
