### PR TITLE
feat: Show OW2 banner only if env var is set

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -12,6 +12,10 @@
 
     <div class="logo-background logo-background--overwatch">
       <%= render "filter/quick_filter" %>
+
+      <% if ENV["BANNER_ROOT"] == "OW2" %>
+        <%= render "application/banners/overwatch_2" %>
+      <% end %>
     </div>
   <% end %>
 


### PR DESCRIPTION
This PR makes it so we can set the OW2 banner on the homepage conditionally with an env variable. I decided to go with a general variable for the banner so we could potentially use it for other banners later down the line.