### PR TITLE
chore: Remove Google Analytics

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,6 @@ Rails.start()
 Turbolinks.start()
 TurbolinksPrefetch.start()
 
-import * as analytics from "../src/analytics"
 import * as aprilFools from "../src/april-fools"
 import * as carousel from "../src/carousel"
 import * as carouselCards from "../src/carousel-cards"
@@ -41,7 +40,6 @@ import * as toggleContent from "../src/toggle-content"
 import * as wikiSearch from "../src/wiki/search"
 
 document.addEventListener("turbolinks:load", function() {
-  analytics.send()
   aprilFools.inject()
 
   copy.bind()

--- a/app/javascript/src/analytics.js
+++ b/app/javascript/src/analytics.js
@@ -1,8 +1,0 @@
-export function send() {
-  if (typeof ga === "function") {
-    gtag("config", "UA-46852314-10", {
-      "anonymize_ip": true,
-      "page_location": event.data.url
-    })
-  }
-}

--- a/app/javascript/src/copy.js
+++ b/app/javascript/src/copy.js
@@ -34,9 +34,9 @@ export default function copyToClipboard(event, optionalContent = undefined) {
 
   setTimeout(() => { copyParent.querySelector(".copy__notification").remove() }, 1000)
 
-  if (targetElement.dataset.trackCopy != undefined) trackCopyGA(targetElement.textContent)
+  if (targetElement.dataset.trackCopy != undefined) trackCopy(targetElement.textContent)
 }
 
-function trackCopyGA(label) {
+function trackCopy(label) {
   new FetchRails("/copy-code", { code: label }).post()
 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -144,10 +144,21 @@ class Post < ApplicationRecord
         from: 0,
         size: size,
         query: {
-          multi_match: {
-            query: query,
-            fields: ["code^4", "title^3", "tags^2", "categories", "maps", "heroes", "user.username^1.5"],
-            fuzziness: "AUTO"
+          function_score: {
+            query: {
+              multi_match: {
+                query: query,
+                fields: ["code^4", "title^3", "tags^2.5", "categories", "maps", "heroes", "user.username^1.5"],
+                fuzziness: "AUTO"
+              }
+            },
+            field_value_factor: {
+              field: "hotness",
+              modifier: "log1p",
+              factor: 0.1
+            },
+            boost_mode: "sum",
+            max_boost: 2
           }
         }
       }).records.ids

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -144,21 +144,10 @@ class Post < ApplicationRecord
         from: 0,
         size: size,
         query: {
-          function_score: {
-            query: {
-              multi_match: {
-                query: query,
-                fields: ["code^4", "title^3", "tags^2.5", "categories", "maps", "heroes", "user.username^1.5"],
-                fuzziness: "AUTO"
-              }
-            },
-            field_value_factor: {
-              field: "hotness",
-              modifier: "log1p",
-              factor: 0.1
-            },
-            boost_mode: "sum",
-            max_boost: 2
+          multi_match: {
+            query: query,
+            fields: ["code^4", "title^3", "tags^2", "categories", "maps", "heroes", "user.username^1.5"],
+            fuzziness: "AUTO"
           }
         }
       }).records.ids

--- a/app/views/application/_analytics_code.html.erb
+++ b/app/views/application/_analytics_code.html.erb
@@ -1,8 +1,0 @@
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-46852314-10"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag("js", new Date());
-
-  gtag("config", "UA-46852314-10", { "anonymize_ip": true });
-</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,8 +36,6 @@
       <%= stylesheet_link_tag "logged_in_user.css" %>
       <%= javascript_pack_tag "logged-in-user.js", "data-turbolinks-track": "reload", defer: true %>
     <% end %>
-
-    <%= render "analytics_code" %>
   </head>
 
   <body class="<%= accessibility_settings if current_user.present? %> <%= "wiki" if is_wiki? %>">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,5 +1,5 @@
 <h1 class="heading">Privacy Policy for <strong>Workshop.codes</strong></h1>
-<p><em>Last Updated: January 19th, 2022</em></p>
+<p><em>Last Updated: June 18th, 2022</em></p>
 
 <p>This page details the data we collect, what we do with collected data, how long we keep that data, and how you can request the deletion of said data.</p>
 
@@ -50,21 +50,6 @@
   <tr>
     <th>Cookie name</th>
     <th>Description</th>
-  </tr>
-
-  <tr>
-    <td>_gat_gtag_[xxx]</td>
-    <td>Used by Google Analytics to throttle request rate.</td>
-  </tr>
-
-  <tr>
-    <td>_ga</td>
-    <td>Used by Google Analytics to distinguish users.</td>
-  </tr>
-
-  <tr>
-    <td>_gid</td>
-    <td>Used by Google Analytics to distinguish users.</td>
   </tr>
 
   <tr>
@@ -129,13 +114,6 @@
     <td>Provide alternative login method</td>
     <td>Request for authorization on behalf of end user</td>
     <td><%= link_to "https://discord.com/privacy", "https://discord.com/privacy", target: "_blank", rel: "noreferrer noopener" %></td>
-  </tr>
-
-  <tr>
-    <td>Google Analytics</td>
-    <td>Site traffic analytics</td>
-    <td>Request metadata*, browser-stored cookies</td>
-    <td><%= link_to "https://policies.google.com/privacy", "https://policies.google.com/privacy", target: "_blank", rel: "noreferrer noopener" %></td>
   </tr>
 
   <tr>


### PR DESCRIPTION
This PR removes Google Analytics and all of it's components. At the moment we don't use it much and we're better off with the increased speed, better user experience, and without selling out our users.