### PR TITLE
refactor: use query parameters instead of path-based parameters

### DIFF
--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -1,7 +1,12 @@
 class FilterController < ApplicationController
   def index
     # REFACTOR: Make this set of attributes have a single source of accessible truth
-    redirect_to filter_path(params.permit([:category, :hero, :map, :from, :to, :sort, :expired, :author, :players, :language, :search, :default, :page])), status: :moved_permanently
+    filtered_params = params.permit([:category, :hero, :map, :from, :to, :sort, :expired, :author, :players, :language, :search, :default, :page])
+    respond_to do |format|
+      format.html   { redirect_to filter_path(filtered_params), status: :moved_permanently }
+      format.js     { redirect_to filter_path(filtered_params), status: :moved_permanently }
+      format.json   { redirect_to filter_path(filtered_params), status: :moved_permanently }
+    end
   end
 
   def get_verified_users

--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -1,79 +1,12 @@
 class FilterController < ApplicationController
   def index
-    begin
-      if params[:search]
-        ids = Post.search(params[:search])
-        @posts = Post.includes(:user)
-                     .where(id: ids)
-                     .order_by_ids(ids)
-                     .select_overview_columns.public?
-      else
-        @posts = Post.select_overview_columns.public?
-      end
-
-      @user = User.find_by_username(params[:author]) if params[:author]
-      @posts = @posts.where(user_id: @user.present? ? @user.id : -1) if params[:author]
-
-      @posts = @posts.where(locale: params[:language]) if params[:language]
-      @posts = @posts.where("created_at >= ?", params[:from]) if params[:from]
-      @posts = @posts.where("created_at <= ?", params[:to]) if params[:to]
-      @posts = @posts.where("last_revision_created_at > ?", 6.months.ago) if params[:expired]
-      @posts = @posts.where("overwatch_2_compatible", true) if params[:overwatch_2]
-
-      @posts = @posts.order("#{ sort_switch } DESC") if params[:sort]
-
-      @posts = @posts.select { |post| to_slug(post.categories).include?(to_slug(params[:category])) } if params[:category]
-      @posts = @posts.select { |post| to_slug(post.maps).include?(to_slug(params[:map])) } if params[:map]
-      @posts = @posts.select { |post| to_slug(post.heroes).include?(to_slug(params[:hero])) } if params[:hero]
-      @posts = @posts.select { |post| helpers.has_player_range?(post) && to_range(params[:players]).overlaps?((post.min_players)..(post.max_players)) } if params[:players]
-      @posts = @posts.select { |post| post.code.upcase.start_with?(params[:code].upcase) } if params[:code]
-
-      @posts = Kaminari.paginate_array(@posts).page(params[:page])
-    rescue Elasticsearch::Transport::Transport::ServerError => e
-      Bugsnag.notify(e) if Rails.env.production?
-      @posts = Kaminari.paginate_array([]).page(params[:page])
-      @error = "Something went wrong. Please try again later."
-      flash[:error] = @error
-      respond_to do |format|
-        format.html { render "filter/index", status: 500 }
-        format.js { render "posts/infinite_scroll_posts", status: 500 }
-        format.json { render json: { message: @message }, status: 500 }
-      end
-      return
-    end
-
-    respond_to do |format|
-      format.html
-      format.js { render "posts/infinite_scroll_posts" }
-      format.json {
-        set_request_headers
-        render json: @posts
-      }
-    end
+    # REFACTOR: Make this set of attributes have a single source of accessible truth
+    redirect_to filter_path(params.permit([:category, :hero, :map, :from, :to, :sort, :expired, :author, :players, :language, :search, :default, :page])), status: :moved_permanently
   end
 
   def get_verified_users
     @verified_users = User.where(verified: true).order(username: :asc).includes(:posts).with_attached_profile_image
 
     render layout: false
-  end
-
-  private
-
-  def sort_switch
-    case params[:sort]
-    when "views"
-      "impressions_count"
-    when "favorites"
-      "favorites_count"
-    when "created"
-      "created_at"
-    when "updated"
-      "updated_at"
-    when "on-fire"
-      "hotness"
-    else
-      "created_at"
-    end
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -28,7 +28,9 @@ class SearchController < ApplicationController
       redirect_to root_path
       return
     end
+
     track_action
+
     begin
       @posts = get_filtered_posts(params)
     rescue Elasticsearch::Transport::Transport::ServerError => e

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,11 +4,22 @@ class SearchController < ApplicationController
   def index
     unless params[:query].empty?
       respond_to do |format|
-        format.js { redirect_to build_filter_path(:search, params[:query].gsub(".", "")) }
-        format.html { redirect_to build_filter_path(:search, params[:query].gsub(".", "")) }
+        format.js { redirect_to build_filter_path(:search, params[:query]) }
+        format.html { redirect_to build_filter_path(:search, params[:query]) }
       end
     else
       redirect_back fallback_location: root_path
+    end
+  end
+
+  def old_index
+    if params[:query].empty?
+      redirect_back fallback_location: root_path
+      return
+    end
+    respond_to do |format|
+      format.js { redirect_to build_filter_path(:search, params[:query]), status: :moved_permanently }
+      format.html { redirect_to build_filter_path(:search, params[:query]), status: :moved_permanently }
     end
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,8 +3,6 @@ class SearchController < ApplicationController
 
   def index
     unless params[:query].empty?
-      track_action
-
       respond_to do |format|
         format.js { redirect_to build_filter_path(:search, params[:query].gsub(".", "")) }
         format.html { redirect_to build_filter_path(:search, params[:query].gsub(".", "")) }
@@ -19,6 +17,7 @@ class SearchController < ApplicationController
       redirect_to root_path
       return
     end
+    track_action
     begin
       @posts = get_filtered_posts(params)
     rescue Elasticsearch::Transport::Transport::ServerError => e

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -12,7 +12,7 @@ class SearchController < ApplicationController
     end
   end
 
-  def old_index
+  def redirect_to_query_params
     if params[:query].empty?
       redirect_back fallback_location: root_path
       return

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,7 +15,33 @@ class SearchController < ApplicationController
   end
 
   def show
-    redirect_to root_path
+    if params.keys.without("controller", "action", "default").length == 0
+      redirect_to root_path
+      return
+    end
+    begin
+      @posts = get_filtered_posts(params)
+    rescue Elasticsearch::Transport::Transport::ServerError => e
+      Bugsnag.notify(e) if Rails.env.production?
+      @posts = Kaminari.paginate_array([]).page(params[:page])
+      @error = "Something went wrong. Please try again later."
+      flash[:error] = @error
+      respond_to do |format|
+        format.html { render "filter/index", status: 500 }
+        format.js { render "posts/infinite_scroll_posts", status: 500 }
+        format.json { render json: { message: @message }, status: 500 }
+      end
+      return
+    end
+
+    respond_to do |format|
+      format.html { render "filter/index" }
+      format.js { render "posts/infinite_scroll_posts" }
+      format.json {
+        set_request_headers
+        render json: @posts
+      }
+    end
   end
 
   private
@@ -25,5 +51,55 @@ class SearchController < ApplicationController
     parameters[:search] = params[:search]
 
     TrackingJob.perform_async(ahoy, "Search", parameters)
+  end
+
+  # @raise [Elasticsearch::Transport::Transport::ServerError] if backend
+  #   ElasticSearch cluster has an issue
+  def get_filtered_posts(params)
+    if params[:search]
+      ids = Post.search(params[:search])
+      posts = Post.includes(:user)
+                   .where(id: ids)
+                   .order_by_ids(ids)
+                   .select_overview_columns.public?
+    else
+      posts = Post.select_overview_columns.public?
+    end
+
+    user = User.find_by_username(params[:author]) if params[:author]
+    posts = posts.where(user_id: @user.present? ? @user.id : -1) if params[:author]
+
+    posts = posts.where(locale: params[:language]) if params[:language]
+    posts = posts.where("created_at >= ?", params[:from]) if params[:from]
+    posts = posts.where("created_at <= ?", params[:to]) if params[:to]
+    posts = posts.where("last_revision_created_at > ?", 6.months.ago) if params[:expired]
+    posts = posts.where("overwatch_2_compatible", true) if params[:overwatch_2]
+
+    posts = posts.order("#{ sort_switch } DESC") if params[:sort]
+
+    posts = posts.select { |post| to_slug(post.categories).include?(to_slug(params[:category])) } if params[:category]
+    posts = posts.select { |post| to_slug(post.maps).include?(to_slug(params[:map])) } if params[:map]
+    posts = posts.select { |post| to_slug(post.heroes).include?(to_slug(params[:hero])) } if params[:hero]
+    posts = posts.select { |post| helpers.has_player_range?(post) && to_range(params[:players]).overlaps?((post.min_players)..(post.max_players)) } if params[:players]
+    posts = posts.select { |post| post.code.upcase.start_with?(params[:code].upcase) } if params[:code]
+
+    posts = Kaminari.paginate_array(posts).page(params[:page])
+  end
+
+  def sort_switch
+    case params[:sort]
+    when "views"
+      "impressions_count"
+    when "favorites"
+      "favorites_count"
+    when "created"
+      "created_at"
+    when "updated"
+      "updated_at"
+    when "on-fire"
+      "hotness"
+    else
+      "created_at"
+    end
   end
 end

--- a/app/javascript/src/filter.js
+++ b/app/javascript/src/filter.js
@@ -34,16 +34,16 @@ function buildFilterPath(event) {
     "overwatch-2": document.querySelector("[data-filter-type='overwatch-2']").checked ? "true" : "",
     "author": filterValue("author"),
     "players": filterValue("players"),
-    "search": document.querySelector("input[name='query']").value.replace(".", " "),
+    "search": document.querySelector("input[name='query']").value,
     "sort": filterValue("sort"),
     "language": filterValue("language")
   }
 
   buildPath = Object.fromEntries(Object.entries(buildPath).filter(([k, v]) => v != ""))
-  buildPath = Object.entries(buildPath).map(([k, v]) => `${ k }/${ v }`).join("/")
+  buildPath = Object.entries(buildPath).map(([k, v]) => `${ k }=${ v }`).join("&")
   const currentLocale = document.querySelector("[data-filter-locale]").dataset.filterLocale
 
-  window.location = "/" + (currentLocale == "en" ? "" : currentLocale + "/") + buildPath
+  window.location = `/${ currentLocale == "en" ? "" : currentLocale + "/" }search?${ buildPath }`
 }
 
 function filterValue(type) {

--- a/app/javascript/src/infinite-scroll.js
+++ b/app/javascript/src/infinite-scroll.js
@@ -39,21 +39,23 @@ function getInfiniteScrollContent(element) {
 
   element.innerHTML = "<div class='spinner'></div>"
 
-  const currentUrl = element.dataset.url.replace(".js", "")
-  const splitUrl = currentUrl.split("page/")
-  let nextUrl = ""
+  // Get last requested post set URL
+  const requestUrl = new URL(element.dataset.url)
 
-  if (splitUrl.length > 1) {
-    const prefix = splitUrl[0]
-    const pageNumber = splitUrl[1]
-    nextUrl = prefix + "page/" + (parseInt(pageNumber) + 1)
+  // Increment page parameter
+  if (requestUrl.searchParams.get("page") != null) {
+    requestUrl.searchParams.set("page", Number(requestUrl.searchParams.get("page")) + 1)
   } else {
-    nextUrl = currentUrl + "/page/2"
+    requestUrl.searchParams.set("page", 2)
   }
+
+  // Ensure request is interpreted as requesting JavaScript response
+  if (!requestUrl.pathname.endsWith(".js")) requestUrl.pathname += ".js"
+  const requestUrlString = requestUrl.toString()
 
   Rails.ajax({
     type: "get",
-    url: nextUrl + ".js",
+    url: requestUrlString,
     success: (response) => {
       progressBar.setValue(1)
       progressBar.hide()
@@ -62,7 +64,7 @@ function getInfiniteScrollContent(element) {
       if (spinner) spinner.remove()
       if (element.dataset.loadMethod === "load-more-button") {
         element.innerHTML = "Load more"
-        element.setAttribute("data-url", nextUrl)
+        element.setAttribute("data-url", requestUrlString)
       }
     },
     error: (error) => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,7 +116,7 @@ Rails.application.routes.draw do
     get "search", to: "search#show", as: "filter"
     post "search", to: "search#index", as: "search_post"
     get "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/(page/:page)", to: "filter#index", constraints: FilterContraints
-    post "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/search", to: "search#old_index"
+    post "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/search", to: "search#redirect_to_query_params"
     get "overwatch-2", to: "filter#index", overwatch_2: "true", as: "overwatch_2"
     get "get-verified-users", to: "filter#get_verified_users"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,10 +113,10 @@ Rails.application.routes.draw do
     get "raw-snippet/:id(.:format)", to: "revisions#raw_snippet", as: "raw_snippet", format: :json
 
     get "(page/:page)", to: "posts#index"
-    get "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/(page/:page)", to: "filter#index", as: "filter", constraints: FilterContraints
+    get "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/(page/:page)", to: "filter#index", constraints: FilterContraints
     post "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/search", to: "search#index", as: "search_post"
     get "overwatch-2", to: "filter#index", overwatch_2: "true", as: "overwatch_2"
-    get "search", to: "search#show"
+    get "search", to: "search#show", as: "filter"
     get "get-verified-users", to: "filter#get_verified_users"
 
     resources :collections, path: "c", param: :nice_url, concerns: :paginatable, only: [:index, :edit, :update, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,10 +113,11 @@ Rails.application.routes.draw do
     get "raw-snippet/:id(.:format)", to: "revisions#raw_snippet", as: "raw_snippet", format: :json
 
     get "(page/:page)", to: "posts#index"
-    get "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/(page/:page)", to: "filter#index", constraints: FilterContraints
-    post "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/search", to: "search#index", as: "search_post"
-    get "overwatch-2", to: "filter#index", overwatch_2: "true", as: "overwatch_2"
     get "search", to: "search#show", as: "filter"
+    post "search", to: "search#index", as: "search_post"
+    get "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/(page/:page)", to: "filter#index", constraints: FilterContraints
+    post "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/search", to: "search#old_index"
+    get "overwatch-2", to: "filter#index", overwatch_2: "true", as: "overwatch_2"
     get "get-verified-users", to: "filter#get_verified_users"
 
     resources :collections, path: "c", param: :nice_url, concerns: :paginatable, only: [:index, :edit, :update, :destroy]

--- a/spec/requests/search_urls_spec.rb
+++ b/spec/requests/search_urls_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "SearchUrls", type: :request do
+  describe "GET old search URLs" do
+    it "redirects a simple old URL" do
+      get "/heroes/reinhardt"
+      expect(response).to have_http_status(:moved_permanently)
+    end
+
+    it "redirects a more complex old URL" do
+      get "/categories/1vs1/maps/hanamura"
+      expect(response).to have_http_status(:moved_permanently)
+    end
+
+    it "gives JSON when requested" do
+      get "/heroes/reinhardt.json"
+      expect(response.content_type).to start_with("application/json")
+    end
+
+    it "redirects GET /search with no parameters to home" do
+      get "/search"
+      expect(response).to have_http_status(:found)
+    end
+  end
+
+  describe "POST to old search URLs" do
+    it "redirects an old search with one filter" do
+      post "/maps/havana/search", params: { "query": "zombie" }
+      expect(response).to have_http_status(:moved_permanently)
+    end
+
+    it "redirects an old search with many filters" do
+      post "/heroes/lucio/maps/paris/search", params: { "query": "see you move" }
+      expect(response).to have_http_status(:moved_permanently)
+    end
+  end
+
+  describe "POST to new search URL" do
+    it "redirects a search with no filters" do
+      post "/search", params: { "query": "banana" }
+      expect(response).to have_http_status(:found)
+    end
+
+    it "redirects a search with filters" do
+      post "/search", params: { "query": "banana", "heroes": "dva", "map": "hanamura" }
+      expect(response).to have_http_status(:found)
+    end
+  end
+end


### PR DESCRIPTION
As detailed in #165, query parameters are easier to work with for applications integrating with Workshop.codes, and may be better understood by SEO algorithms.

Resolves #165
