### PR TITLE
chore: Avoid deprecation warning for encrypted email

### DIFF
--- a/app/models/email_notification.rb
+++ b/app/models/email_notification.rb
@@ -1,7 +1,7 @@
 class EmailNotification < ApplicationRecord
   belongs_to :post
 
-  encrypts :email
+  has_encrypted :email
 
   enum content_type: { will_expire: 0 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
   enum level: { regular: 0, admin: 1, banned: 2, arbiter: 3 }
   enum pagination_type: { infinite_scroll: 0, load_more: 1, pagination: 2 }
 
-  encrypts :email
+  has_encrypted :email
   blind_index :email
 
   validates :username, presence: true, uniqueness: { case_sensitive: false }, uniqueness_against_nice_url: true, format: { with: /\A[\d\p{L}_-]*[#\d]*\z/i }, length: { maximum: 32 }


### PR DESCRIPTION
Due to [this change in Lockbox](https://github.com/ankane/lockbox/commit/7477de8bfba5c7f0bf3d77c1cafd85e9411ae92b), it is necessary to rename `encrypts` to `has_encrypted`.
