### PR TITLE
feat: Improve focus states for several form elements

### DIFF
--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -63,3 +63,23 @@
     outline: none;
   }
 }
+
+@mixin focus-visible-outline($prepend: '') {
+  outline-offset: 0;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: outline-offset 150ms;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $pure-white;
+
+    &:not(:active) {
+      @if $prepend == inset {
+        outline-offset: -2px;
+      } @else {
+        outline-offset: 3px;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/elements/_header.scss
+++ b/app/assets/stylesheets/elements/_header.scss
@@ -47,7 +47,7 @@
       width: 100%;
       height: 100vh;
       background: $bg-darker;
-      z-index: 50;
+      z-index: 100;
       animation: fade-in-header-content 200ms;
     }
   }

--- a/app/assets/stylesheets/elements/_logo.scss
+++ b/app/assets/stylesheets/elements/_logo.scss
@@ -23,6 +23,7 @@
 }
 
 .logo-link {
+  border-radius: $border-radius / 2;
   @include focus-visible-outline;
 
   @include hover-stack {

--- a/app/assets/stylesheets/elements/_logo.scss
+++ b/app/assets/stylesheets/elements/_logo.scss
@@ -23,6 +23,8 @@
 }
 
 .logo-link {
+  @include focus-visible-outline;
+
   @include hover-stack {
     filter: brightness(1.05);
   }

--- a/app/assets/stylesheets/elements/_navigation.scss
+++ b/app/assets/stylesheets/elements/_navigation.scss
@@ -26,6 +26,8 @@
   font-size: 21px;
   font-size-adjust: 0.52;
 
+  @include focus-visible-outline;
+
   @include media-min(mbl) {
     font-size: clamp(22px, 2vw, 28px);
     margin-right: clamp(#{ $margin / 8 }, 1.25vw, #{ $margin / 2 });
@@ -88,12 +90,18 @@
   font-weight: bolder;
   text-decoration: none;
 
+  @include focus-visible-outline;
+
   @include media-min(sm) {
     margin-left: 1rem;
   }
 
   @include media-min(mbl) {
     display: none;
+  }
+
+  &:focus {
+    color: white;
   }
 }
 

--- a/app/assets/stylesheets/elements/_navigation.scss
+++ b/app/assets/stylesheets/elements/_navigation.scss
@@ -19,6 +19,7 @@
 .navigation__item {
   display: block;
   margin-bottom: $margin / 4;
+  border-radius: $border-radius / 2;
   color: $pure-white;
   text-decoration: none;
   font-family: "Barlow Condensed", "Impact";

--- a/app/assets/stylesheets/elements/_noui-slider.scss
+++ b/app/assets/stylesheets/elements/_noui-slider.scss
@@ -152,11 +152,11 @@
   background: $white;
   cursor: pointer;
 
+  @include focus-visible-outline;
+
   @include hover-stack {
     background: $pure-white;
-    outline: none;
   }
-
 }
 
 /* Handle stripes;

--- a/app/assets/stylesheets/general/_form.scss
+++ b/app/assets/stylesheets/general/_form.scss
@@ -9,8 +9,11 @@
   font-size: $font-size-base;
   color: $white;
 
-  &:focus {
+  &:focus,
+  &:focus-within {
     outline: none;
+    background: lighten($bg-dark, 5%);
+    box-shadow: 0 0 0 2px rgba($pure-white, 0.25);
   }
 
   &::placeholder {
@@ -34,10 +37,6 @@
       line-height: 1.5em;
     }
 
-    &:focus {
-      background: lighten($bg-dark, 2.55%);
-    }
-
     .simple-view & {
       box-shadow: 0 0 0 5px $body-bg;
     }
@@ -53,6 +52,10 @@
 
   .standout & {
     background: darken($bg-dark, 5%);
+
+    &:focus {
+      background: darken($bg-dark, 2.5%);
+    }
   }
 }
 
@@ -136,6 +139,8 @@
 
   &:focus {
     outline: none;
+    background-color: lighten($bg-dark, 5%);
+    box-shadow: 0 0 0 2px rgba($pure-white, 0.25);
   }
 
   &:not(multiple) {
@@ -174,6 +179,8 @@
     border: 2px solid $text-color;
     cursor: pointer;
 
+    @include focus-visible-outline;
+
     &[type="radio"] {
       border-radius: 50%;
     }
@@ -188,7 +195,6 @@
     }
 
     &:focus {
-      outline: none;
       border-color: lighten($gray, 20%);
     }
   }

--- a/app/assets/stylesheets/logged_in_user/_switch.scss
+++ b/app/assets/stylesheets/logged_in_user/_switch.scss
@@ -95,7 +95,7 @@
       border-color: $text-color;
     }
   }
-  
+
   &::before {
     @extend .switch, ::before;
     height: calc(1rem - 8px);
@@ -115,7 +115,8 @@
     width: 2rem;
     pointer-events: all;
 
-    .switch-checkbox__input:checked + & {
+    .switch-checkbox__input:checked + &,
+    .switch-checkbox:focus-within & {
       border-color: $white;
     }
   }

--- a/app/javascript/src/components/form/Dropzone.svelte
+++ b/app/javascript/src/components/form/Dropzone.svelte
@@ -138,10 +138,10 @@
 
   <small>{ help }</small>
 
-  <label class="dropzone__button button button--secondary mt-1/4">
+  <label class="dropzone__button button button--secondary mt-1/4" tabindex="0">
     { button }
 
-    <input type="file" multiple="true" on:change={ changeInput } />
+    <input type="file" multiple="true" on:change={ changeInput } tabindex="-1" />
   </label>
 </div>
 


### PR DESCRIPTION
This PR improves the `focus` and `focus-visible` states for several elements, mainly form elements. `focus-visible` is only visible when using keyboard navigation. This focus should always be clearly visible and the way it looks is far less important than the functionality.

![focus-visible](https://user-images.githubusercontent.com/12848235/182037178-9ea6ac5c-825e-47e6-b759-44f93504aeca.gif)
![focus-visible-2](https://user-images.githubusercontent.com/12848235/182037250-b3a8a24b-aa36-49b0-8e23-4ea64b0a1ad1.gif)

The regular focus state for form elements was previously non existent. I've added a slight highlight and outline to inputs.
![image](https://user-images.githubusercontent.com/12848235/182037239-738e4306-8d72-48df-bb50-42436f630639.png)
![image](https://user-images.githubusercontent.com/12848235/182037246-325ce6b9-93f7-49b0-a96b-49227bf268f8.png)
