### PR TITLE
fix: Search filters not properly applying

### DIFF
--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -1,7 +1,7 @@
 class FilterController < ApplicationController
   def index
     # REFACTOR: Make this set of attributes have a single source of accessible truth
-    filtered_params = params.permit([:category, :hero, :map, :from, :to, :sort, :expired, :author, :players, :language, :search, :default, :page])
+    filtered_params = params.permit([:category, :hero, :map, :from, :to, :sort, :expired, :author, :players, :language, :search, :page])
     respond_to do |format|
       format.html   { redirect_to filter_path(filtered_params), status: :moved_permanently }
       format.js     { redirect_to filter_path(filtered_params), status: :moved_permanently }

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -72,7 +72,7 @@ class SearchController < ApplicationController
   # @raise [Elasticsearch::Transport::Transport::ServerError] if backend
   #   ElasticSearch cluster has an issue
   def get_filtered_posts(params)
-    if params[:search]
+    if params[:search] && ENV["BONSAI_URL"]
       ids = Post.search(params[:search])
       posts = Post.includes(:user)
                    .where(id: ids)

--- a/app/javascript/src/filter.js
+++ b/app/javascript/src/filter.js
@@ -25,13 +25,13 @@ function buildFilterPath(event) {
   linkElement.innerHTML = "<div class='spinner spinner--small'></div>"
 
   let buildPath = {
-    "categories": filterValue("categories"),
-    "heroes": filterValue("heroes"),
-    "maps": filterValue("maps"),
+    "category": filterValue("categories"),
+    "hero": filterValue("heroes"),
+    "map": filterValue("maps"),
     "from": filterValue("from"),
     "to": filterValue("to"),
-    "exclude-expired": document.querySelector("[data-filter-type='exclude-expired']").checked ? "true" : "",
-    "overwatch-2": document.querySelector("[data-filter-type='overwatch-2']").checked ? "true" : "",
+    "expired": document.querySelector("[data-filter-type='exclude-expired']").checked ? "true" : "",
+    "overwatch_2": document.querySelector("[data-filter-type='overwatch-2']").checked ? "true" : "",
     "author": filterValue("author"),
     "players": filterValue("players"),
     "search": document.querySelector("input[name='query']").value,

--- a/spec/requests/search_urls_spec.rb
+++ b/spec/requests/search_urls_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe "SearchUrls", type: :request do
   describe "GET old search URLs" do
     it "redirects a simple old URL" do
       get "/heroes/reinhardt"
+
       expect(response).to have_http_status(:moved_permanently)
       expect(response).to redirect_to(filter_path(params: { hero: "reinhardt" }))
     end
 
     it "redirects a more complex old URL" do
       get "/categories/1vs1/maps/hanamura"
+
       expect(response).to have_http_status(:moved_permanently)
       expect(response).to redirect_to(filter_path(params: {
         category: "1vs1",
@@ -19,6 +21,7 @@ RSpec.describe "SearchUrls", type: :request do
 
     it "gives JSON when requested" do
       get "/heroes/reinhardt.json"
+
       expect(response.content_type).to start_with("application/json")
       expect(response).to have_http_status(:moved_permanently)
       expect(response).to redirect_to(filter_path(params: { hero: "reinhardt" }))
@@ -26,6 +29,7 @@ RSpec.describe "SearchUrls", type: :request do
 
     it "redirects GET /search with no parameters to home" do
       get "/search"
+
       expect(response).to have_http_status(:found)
       expect(response).to redirect_to(root_path)
     end

--- a/spec/requests/search_urls_spec.rb
+++ b/spec/requests/search_urls_spec.rb
@@ -5,28 +5,134 @@ RSpec.describe "SearchUrls", type: :request do
     it "redirects a simple old URL" do
       get "/heroes/reinhardt"
       expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to(filter_path(params: { hero: "reinhardt" }))
     end
 
     it "redirects a more complex old URL" do
       get "/categories/1vs1/maps/hanamura"
       expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to(filter_path(params: {
+        category: "1vs1",
+        map: "hanamura"
+      }))
     end
 
     it "gives JSON when requested" do
       get "/heroes/reinhardt.json"
       expect(response.content_type).to start_with("application/json")
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to(filter_path(params: { hero: "reinhardt" }))
     end
 
     it "redirects GET /search with no parameters to home" do
       get "/search"
       expect(response).to have_http_status(:found)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "GET new search URLs" do
+    it "handles a query alone" do
+      search_params = {
+        search: "charles the 9th"
+      }
+      get filter_path(params: search_params)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("charles the 9th")
+    end
+
+    context "with filters and no query" do
+      it "handles a single filter" do
+        search_params = {
+          map: "dorado"
+        }
+        get filter_path(params: search_params)
+
+        expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Dorado")
+      end
+
+      it "handles multiple filters" do
+        search_params = {
+          map: "hanamura",
+          category: "scrims",
+          hero: "wrecking-ball"
+        }
+        get filter_path(params: search_params)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Hanamura")
+        expect(response.body).to include("scrims")
+        expect(response.body).to include("Wrecking Ball")
+      end
+    end
+
+    context "with filters and a query" do
+      it "handles a single filter and a query" do
+        search_params = {
+          expired: true,
+          search: "charles the 9th"
+        }
+        get filter_path(params: search_params)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("expired")
+        expect(response.body).to include("charles the 9th")
+      end
+
+      it "handles multiple filters and a query" do
+        search_params = {
+          map: "temple-of-anubis",
+          category: "tools",
+          hero: "wrecking-ball",
+          sort: "views",
+          search: "charles the 9th"
+        }
+        get filter_path(params: search_params)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Temple Of Anubis")
+        expect(response.body).to include("tools")
+        expect(response.body).to include("Wrecking Ball")
+        expect(response.body).to include("views")
+        expect(response.body).to include("charles the 9th")
+      end
     end
   end
 
   describe "POST to old search URLs" do
-    it "redirects an old search with one filter" do
-      post "/maps/havana/search", params: { "query": "zombie" }
-      expect(response).to have_http_status(:moved_permanently)
+    context "using path-based parameters" do
+      it "redirects an old search with one filter" do
+        search_params = {
+          query: "zombie"
+        }
+        post "/maps/havana/search", params: search_params
+        # :query is renamed to :search
+        search_params[:search] = search_params.delete(:query)
+
+        search_params = search_params.merge({
+          map: "havana"
+        })
+        expect(response).to have_http_status(:moved_permanently)
+        expect(response).to redirect_to(filter_path(params: search_params))
+      end
+
+      it "redirects an old search with many filters" do
+        search_params = {
+          query: "see you move"
+        }
+        post "/heroes/lucio/maps/paris/search", params: search_params
+        # :query is renamed to :search
+        search_params[:search] = search_params.delete(:query)
+
+        search_params = search_params.merge({
+          hero: "lucio",
+          map: "paris"
+        })
+        expect(response).to have_http_status(:moved_permanently)
+        expect(response).to redirect_to(filter_path(params: search_params))
+      end
     end
 
     it "redirects an old search with many filters" do
@@ -37,13 +143,27 @@ RSpec.describe "SearchUrls", type: :request do
 
   describe "POST to new search URL" do
     it "redirects a search with no filters" do
-      post "/search", params: { "query": "banana" }
+      search_params = { query: "banana" }
+      post "/search", params: search_params
+      # :query is renamed to :search
+      search_params[:search] = search_params.delete(:query)
+
       expect(response).to have_http_status(:found)
+      expect(response).to redirect_to(filter_path(params: search_params))
     end
 
     it "redirects a search with filters" do
-      post "/search", params: { "query": "banana", "heroes": "dva", "map": "hanamura" }
+      search_params = {
+        query: "banana",
+        hero: "dva",
+        map: "hanamura"
+      }
+      post "/search", params: search_params
+      # :query is renamed to :search
+      search_params[:search] = search_params.delete(:query)
+
       expect(response).to have_http_status(:found)
+      expect(response).to redirect_to(filter_path(params: search_params))
     end
   end
 end


### PR DESCRIPTION
Due to changes made in #171, the previous `filter.js` improperly named its query parameters, meaning the filters did not function. This PR rectifies that.

Examples:
`categories=___` -> `category=___`
`maps=___` -> `map=___`
