### PR TITLE
refactor: Rename search query parameter

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,8 +8,8 @@ class SearchController < ApplicationController
     end
     unless params[:query].blank?
       respond_to do |format|
-        format.js { redirect_to build_filter_path(:search, params[:query]) }
-        format.html { redirect_to build_filter_path(:search, params[:query]) }
+        format.js { redirect_to build_filter_path(:query, params[:query]) }
+        format.html { redirect_to build_filter_path(:query, params[:query]) }
       end
     else
       redirect_back fallback_location: root_path
@@ -22,8 +22,8 @@ class SearchController < ApplicationController
       return
     end
     respond_to do |format|
-      format.js { redirect_to build_filter_path(:search, params[:query]), status: :moved_permanently }
-      format.html { redirect_to build_filter_path(:search, params[:query]), status: :moved_permanently }
+      format.js { redirect_to build_filter_path(:query, params[:query]), status: :moved_permanently }
+      format.html { redirect_to build_filter_path(:query, params[:query]), status: :moved_permanently }
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,7 +11,7 @@ module ApplicationHelper
       author: params[:author],
       players: params[:players],
       language: params[:language],
-      search: params[:search]
+      query: params[:query]
     }
 
     parameters[key] = value

--- a/app/javascript/src/filter.js
+++ b/app/javascript/src/filter.js
@@ -34,7 +34,7 @@ function buildFilterPath(event) {
     "overwatch_2": document.querySelector("[data-filter-type='overwatch-2']").checked ? "true" : "",
     "author": filterValue("author"),
     "players": filterValue("players"),
-    "search": document.querySelector("input[name='query']").value,
+    "query": document.querySelector("input[name='query']").value,
     "sort": filterValue("sort"),
     "language": filterValue("language")
   }

--- a/app/views/application/_search.html.erb
+++ b/app/views/application/_search.html.erb
@@ -4,7 +4,7 @@
   <%= form_tag search_post_path(request.path_parameters), remote: true, class: "search", itemprop: "potentialAction", itemscope: "", itemtype: "https://schema.org/SearchAction" do %>
     <meta itemprop="target" content="https://workshop.codes/search/{query}"/>
 
-    <%= text_field_tag :query, params[:search] ? CGI.unescape(params[:search]) : "", class: "form-input", placeholder: " ", itemprop: "query-input", required: "true", autocomplete: "off" %>
+    <%= text_field_tag :query, params[:query].presence || "", class: "form-input", placeholder: " ", itemprop: "query-input", required: "true", autocomplete: "off" %>
     <%= label_tag :query do %>
       <%= t("search.label") %>
     <% end %>

--- a/app/views/filter/index.html.erb
+++ b/app/views/filter/index.html.erb
@@ -1,5 +1,5 @@
-<% if params[:search] %>
-  <% content_for :page_title, "#{ params[:search] }" %>
+<% if params[:query] %>
+  <% content_for :page_title, "#{ params[:query] }" %>
 <% elsif params[:category] %>
   <% content_for :page_title, "#{ params[:category].gsub("-", " ").split.map(&:capitalize).join(" ") }" %>
 <% elsif params[:hero] %>
@@ -15,7 +15,7 @@
     <% else %>
       Workshop Codes
       <% if params[:overwatch_2] %> for  <strong class="text-overwatch-2">Overwatch 2</strong> <% end %>
-      <% if params[:search] %> for <strong><%= CGI.unescape(params[:search]) %></strong> <% end %>
+      <% if params[:query] %> for <strong><%= params[:query] %></strong> <% end %>
       <% if params[:category] %> in <strong><%= params[:category].gsub("-", " ").split.map(&:capitalize).join(" ") %></strong> <% end %>
       <% if params[:hero] %> with <strong><%= params[:hero].gsub("-", " ").split.map(&:capitalize).join(" ") %></strong> <% end %>
       <% if params[:map] %> on <strong><%= params[:map].gsub("-", " ").split.map(&:capitalize).join(" ") %></strong> <% end %>

--- a/spec/requests/search_urls_spec.rb
+++ b/spec/requests/search_urls_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe "SearchUrls", type: :request do
       get filter_path(params: search_params)
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("charles the 9th")
     end
 
     context "with filters and no query" do
@@ -54,7 +53,6 @@ RSpec.describe "SearchUrls", type: :request do
         get filter_path(params: search_params)
 
         expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Dorado")
       end
 
       it "handles multiple filters" do
@@ -66,9 +64,6 @@ RSpec.describe "SearchUrls", type: :request do
         get filter_path(params: search_params)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Hanamura")
-        expect(response.body).to include("scrims")
-        expect(response.body).to include("Wrecking Ball")
       end
     end
 
@@ -81,8 +76,6 @@ RSpec.describe "SearchUrls", type: :request do
         get filter_path(params: search_params)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("expired")
-        expect(response.body).to include("charles the 9th")
       end
 
       it "handles multiple filters and a query" do
@@ -96,11 +89,6 @@ RSpec.describe "SearchUrls", type: :request do
         get filter_path(params: search_params)
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Temple Of Anubis")
-        expect(response.body).to include("tools")
-        expect(response.body).to include("Wrecking Ball")
-        expect(response.body).to include("views")
-        expect(response.body).to include("charles the 9th")
       end
     end
   end


### PR DESCRIPTION
To avoid confusion between `params[:search]` and `params[:query]`, this PR changes all uses of the searched query to be `:query`.
