### PR TITLE
chore: Update robots.txt with Yandex and PetalBot

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,8 @@
 Sitemap: https://workshop.codes/sitemap.xml
 
+User-agent: *
+Crawl-delay: 5
+
 User-agent: SemrushBot
 Disallow: /
 
@@ -20,6 +23,12 @@ Disallow: /
 
 User-agent: Twitterbot
 Allow: /
+
+User-agent: Yandex
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
 
 User-agent:*
 Allow: /rails/active_storage/*


### PR DESCRIPTION
This PR updates robots.txt to disallowed Yandex and PetalBot. PetalBot is a chinese bot from Huawei. We have no interest in chinese traffic as our codes won't work anyway. Yandex is Russian, and while a somewhat significant portion of traffic comes from Russia, I see no point in allowing them to index us.

I've also added a crawl-delay (I thought we had this already, but I guess not). This will prevent future bots from crawling too aggressively, as long as they respect it of course.