### PR TITLE
fix: Prevent undefined behavior with blank comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -37,7 +37,9 @@ class CommentsController < ApplicationController
 
       respond_to :js
     else
-      format.js { render "application/error" }
+      respond_to do |format|
+        format.js { render "application/error" }
+      end
     end
   end
 
@@ -57,7 +59,9 @@ class CommentsController < ApplicationController
 
       respond_to :js
     else
-      format.js { render "application/error" }
+      respond_to do |format|
+        format.js { render "application/error" }
+      end
     end
   end
 
@@ -69,7 +73,9 @@ class CommentsController < ApplicationController
 
       respond_to :js
     else
-      format.js { render "application/error" }
+      respond_to do |format|
+        format.js { render "application/error" }
+      end
     end
   end
 
@@ -89,7 +95,9 @@ class CommentsController < ApplicationController
   end
 
   def failed_authenticity_token
-    format.js { render "application/error" }
+    respond_to do |format|
+      format.js { render "application/error" }
+    end
   end
 
   private

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -9,7 +9,7 @@
     <%= form.hidden_field :parent_id, value: parent_id if defined?(parent_id) %>
 
     <div class="form-group">
-      <%= form.text_area :content, class: "form-input form-textarea form-textarea--extra-small bg-darker mw-100", placeholder: "Comment...", data: { role: "comment-input" } %>
+      <%= form.text_area :content, class: "form-input form-textarea form-textarea--extra-small bg-darker mw-100", placeholder: "Comment...", data: { role: "comment-input" }, required: true %>
     </div>
 
     <%= button_tag defined?(comment) ? t("comment.edit") : t("comment.submit"), class: "button mt-1/4" %>

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+require 'rails_helper'
+require './spec/support/user_helpers'
+
+RSpec.configure do |c|
+  c.include Helpers::Users
+end
+
+RSpec.feature "Comments", type: :feature do
+  include Capybara::DSL
+
+  let!(:post_author) { create(:user) }
+  let!(:comment_author) { create(:user, password: "password") }
+  let!(:post) { create(:post, user_id: post_author.id) }
+
+  context "creation", js: true do
+    before(:each) do
+      sign_in_as(comment_author, "password")
+      visit post_tab_path(code: post.code, tab: "comments")
+    end
+
+    it "is allowed for non-empty comments" do
+      fill_in "comment_content", with: "A non-empty comment"
+      # Do not expect HTML5 validation message
+      expect(page).not_to have_field("comment_content", validation_message: /Please fill out this field/)
+
+      find(".comment-form").click_on "Comment"
+
+      within(".comments") do
+        expect(page).to have_text("A non-empty comment")
+      end
+    end
+
+    it "is not allowed for empty comments" do
+      # Expect an HTML5 validation message
+      expect(page).to have_field("comment_content", validation_message: /Please fill out this field/)
+    end
+
+    it "is rejected on the backend when full of whitespace" do
+      fill_in "comment_content", with: "    "
+
+      find(".comment-form").click_on "Comment"
+
+      expect(page).to have_content("Something went wrong when performing that action.")
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes a few minor issues with comment handling. In particular:
- The comments controller did not properly respond with an error due to a lack of an enclosing `respond_to` block
- The comments form did not contain a `required` attribute, which led to poor user feedback.

This PR also contains regression tests to capture the current behavior
