### PR TITLE
test: Prevent rare test interdependency

### DIFF
--- a/spec/features/profiles_spec.rb
+++ b/spec/features/profiles_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe "Profiles", type: :feature do
     it "selects the highlights tab by default if the user has a block" do
       create(:block, user_id: user.id, content_type: :profile, name: "highlight", properties: ActionController::Parameters.new({post: "#{posts.first.id}", description: "This is a highlight"}))
 
-      visit profile_path( user.username )
+      visit profile_path(username: user.username )
       expect(page).to have_link("Highlights", class: "tabs__item--active")
       expect(page).not_to have_link("Codes", class: "tabs__item--active")
     end
 
     it "shows the user's posts if they have no blocks" do
-      visit profile_path( user.username )
+      visit profile_path(username: user.username )
       expect(page).to have_link("Codes", class: "tabs__item--active")
       expect(page).not_to have_link("Highlights", class: "tabs__item--active")
 
@@ -28,7 +28,7 @@ RSpec.describe "Profiles", type: :feature do
     end
 
     it "performs an infinite scroll on the user's posts", js: true do
-      visit profile_path( user.username )
+      visit profile_path(username: user.username)
       expect(page).to have_link("Codes", class: "tabs__item--active")
 
       # Show most recent posts
@@ -56,13 +56,13 @@ RSpec.describe "Profiles", type: :feature do
     it "selects the codes tab even if the user has a block" do
       create(:block, user: user, name: "highlight", properties: "{post: #{posts.first.id}, description: }")
 
-      visit profile_path( user.username , params: { tab: "codes" })
+      visit profile_path(username: user.username , params: { tab: "codes" })
       expect(page).to have_link("Codes", class: "tabs__item--active")
       expect(page).not_to have_link("Highlights", class: "tabs__item--active")
     end
 
     it "selects the collections tab" do
-      visit profile_path( user.username , params: { tab: "collections" })
+      visit profile_path(username: user.username , params: { tab: "collections" })
       expect(page).to have_link("Collections", class: "tabs__item--active")
       expect(page).not_to have_link("Codes", class: "tabs__item--active")
       expect(page).not_to have_link("Highlights", class: "tabs__item--active")

--- a/spec/features/profiles_spec.rb
+++ b/spec/features/profiles_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe "Profiles", type: :feature do
     it "selects the highlights tab by default if the user has a block" do
       create(:block, user_id: user.id, content_type: :profile, name: "highlight", properties: ActionController::Parameters.new({post: "#{posts.first.id}", description: "This is a highlight"}))
 
-      visit "/u/#{ user.username }"
+      visit profile_path( user.username )
       expect(page).to have_link("Highlights", class: "tabs__item--active")
       expect(page).not_to have_link("Codes", class: "tabs__item--active")
     end
 
     it "shows the user's posts if they have no blocks" do
-      visit "/u/#{ user.username }"
+      visit profile_path( user.username )
       expect(page).to have_link("Codes", class: "tabs__item--active")
       expect(page).not_to have_link("Highlights", class: "tabs__item--active")
 
@@ -28,7 +28,7 @@ RSpec.describe "Profiles", type: :feature do
     end
 
     it "performs an infinite scroll on the user's posts", js: true do
-      visit "/u/#{ user.username }"
+      visit profile_path( user.username )
       expect(page).to have_link("Codes", class: "tabs__item--active")
 
       # Show most recent posts
@@ -56,13 +56,13 @@ RSpec.describe "Profiles", type: :feature do
     it "selects the codes tab even if the user has a block" do
       create(:block, user: user, name: "highlight", properties: "{post: #{posts.first.id}, description: }")
 
-      visit "/u/#{ user.username }?tab=codes"
+      visit profile_path( user.username , params: { tab: "codes" })
       expect(page).to have_link("Codes", class: "tabs__item--active")
       expect(page).not_to have_link("Highlights", class: "tabs__item--active")
     end
 
     it "selects the collections tab" do
-      visit "/u/#{ user.username }?tab=collections"
+      visit profile_path( user.username , params: { tab: "collections" })
       expect(page).to have_link("Collections", class: "tabs__item--active")
       expect(page).not_to have_link("Codes", class: "tabs__item--active")
       expect(page).not_to have_link("Highlights", class: "tabs__item--active")

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       I18n.locale = "en"
     end
 
+    after(:each) do
+      I18n.locale = I18n.default_locale
+    end
+
     context "given a valid value to pull" do
 
       it "returns the correct category" do

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Profiles", type: :request do
   let!(:user) { create(:user) }
+  let!(:ko_user) { create(:user, username: "민서") }
   let!(:posts) { create_list(:post, 30, user_id: user.id) }
 
   before :each do
@@ -11,6 +12,11 @@ RSpec.describe "Profiles", type: :request do
   describe "GET /u/:username" do
     it "returns status code 200 for existing username" do
       get "/u/#{ user.username }"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns status code 200 for a user with a non-ASCII username" do
+      get profile_path(username: ko_user.username)
       expect(response).to have_http_status(:ok)
     end
 

--- a/spec/requests/profiles_spec.rb
+++ b/spec/requests/profiles_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Profiles", type: :request do
 
   describe "GET /u/:username" do
     it "returns status code 200 for existing username" do
-      get "/u/#{ user.username }"
+      get profile_path(username: user.username)
       expect(response).to have_http_status(:ok)
     end
 
@@ -21,7 +21,7 @@ RSpec.describe "Profiles", type: :request do
     end
 
     it "returns status code 404 for nonexisting username" do
-      get "/u/user_does_not_exist"
+      get profile_path(username: "does_not_exist")
       expect(response).to have_http_status(:not_found)
     end
   end


### PR DESCRIPTION
Due to a rare test ordering bug, it was possible, though unlikely, for testing of the `application_helper`'s i18n values to cause a test interdependency with the profiles specs. This PR addresses this concern.

Note: Issue was first noticed with `bundle exec rspec --seed 17258` in [this CI run](https://github.com/CactusPuppy/workshop.codes/runs/7799224654?check_suite_focus=true)
