### PR TITLE
chore: Remove simple-view accessibility setting

### DIFF
--- a/app/assets/stylesheets/elements/_backgrounds.scss
+++ b/app/assets/stylesheets/elements/_backgrounds.scss
@@ -50,26 +50,6 @@
     object-fit: cover;
     text-indent: 10000px
   }
-
-  .simple-view & {
-    clip-path: none;
-    background: $border-color;
-    height: 90px;
-
-    @include media-min(xl) {
-      height: 120px;
-    }
-
-    img {
-      display: none;
-    }
-  }
-
-  &--large {
-    .simple-view & {
-      height: 400px;
-    }
-  }
 }
 
 .logo-background {
@@ -115,13 +95,6 @@
   &--overwatch {
     &::after {
       background-image: image-url("layout/overwatch-logo.svg");
-    }
-  }
-
-  .simple-view & {
-    &::before,
-    &::after {
-      display: none;
     }
   }
 }

--- a/app/assets/stylesheets/elements/_buttons.scss
+++ b/app/assets/stylesheets/elements/_buttons.scss
@@ -129,11 +129,6 @@
     margin-right: .5em;
   }
 
-  .simple-view & {
-    border: 0;
-    box-shadow: none;
-  }
-
   .spinner {
     margin-bottom: $margin / 8;
   }

--- a/app/assets/stylesheets/elements/_card.scss
+++ b/app/assets/stylesheets/elements/_card.scss
@@ -120,10 +120,6 @@
   margin: -#{ $margin / 4 } -#{ $margin / 4 } $margin / 4;
   background: $body-bg;
   font-size: 12px;
-
-  .simple-view & {
-    display: none;
-  }
 }
 
 .card__author {

--- a/app/assets/stylesheets/elements/_code.scss
+++ b/app/assets/stylesheets/elements/_code.scss
@@ -51,11 +51,6 @@
       max-width: 280px;
     }
   }
-
-  .simple-view & {
-    background: $bg-dark;
-    border-radius: 0;
-  }
 }
 
 .code__flag {

--- a/app/assets/stylesheets/elements/_dropdown.scss
+++ b/app/assets/stylesheets/elements/_dropdown.scss
@@ -72,11 +72,6 @@
     }
   }
 
-  .simple-view & {
-    box-shadow: none;
-    border: 3px solid lighten($border-color, 10%);
-  }
-
   hr {
     margin: $margin / 6 0;
     background: lighten($bg-dark, 10%);
@@ -108,10 +103,6 @@
     margin-right: .75em;
     border-radius: 50%;
     background-color: $body-bg;
-
-    .simple-view & {
-      display: none;
-    }
   }
 
   small {
@@ -130,10 +121,6 @@
     background-repeat: no-repeat;
     background-position: center;
     background-size: 70%;
-
-    .simple-view & {
-      display: none;
-    }
   }
 }
 

--- a/app/assets/stylesheets/elements/_filter.scss
+++ b/app/assets/stylesheets/elements/_filter.scss
@@ -50,10 +50,6 @@
     box-shadow: 0 0 1.5rem 1.5rem $black;
     border-radius: 99px;
     pointer-events: none;
-
-    .simple-view & {
-      display: none;
-    }
   }
 
   .fading-in & {

--- a/app/assets/stylesheets/elements/_footer.scss
+++ b/app/assets/stylesheets/elements/_footer.scss
@@ -13,10 +13,6 @@
     color: $text-color;
   }
 
-  .simple-view & {
-    border-width: 2px;
-  }
-
   .large-fonts & {
     font-size: 14px;
   }

--- a/app/assets/stylesheets/elements/_items.scss
+++ b/app/assets/stylesheets/elements/_items.scss
@@ -1,12 +1,6 @@
 .items {
   position: relative;
 
-  .simple-view & {
-    hr {
-      display: none;
-    }
-  }
-
   .item:last-of-type {
     border-bottom: 1px solid $border-color;
   }
@@ -102,22 +96,6 @@
       margin-top: $margin * 2;
     }
   }
-
-  .simple-view & {
-    display: grid;
-    grid-template: "title favorite"
-                   "code code";
-    grid-template-columns: calc(100% - #{ $favorite-width * 2 }) $favorite-width * 2;
-    border: 3px solid $border-color;
-    margin-bottom: 1rem;
-    padding: 0;
-
-    @include media-min(sm) {
-      display: grid;
-      grid-template: "title favorite code";
-      grid-template-columns: calc(100% - #{ $code-width } + #{ $favorite-width }) $favorite-width $code-width;
-    }
-  }
 }
 
 .item__favorite {
@@ -126,10 +104,6 @@
 
   @include media-min(sm) {
     margin: 23px $margin / 4 auto;
-  }
-
-  .simple-view & {
-    margin-right: 1rem;
   }
 }
 
@@ -164,10 +138,6 @@
 
   @include hover-stack {
     filter: brightness(1.15);
-  }
-
-  .simple-view & {
-    display: none;
   }
 
   .item--large & {
@@ -261,10 +231,6 @@
   h1 {
     margin: 0;
   }
-
-  .simple-view & {
-    padding: $margin / 3;
-  }
 }
 
 .item__sub-title {
@@ -290,10 +256,6 @@
   .item--bottom & {
     display: block;
     padding: 0;
-  }
-
-  .simple-view & {
-    display: none;
   }
 }
 
@@ -351,10 +313,6 @@
     &:first-child {
       margin-left: 0;
     }
-  }
-
-  .simple-view & {
-    padding: 0 1rem;
   }
 }
 

--- a/app/assets/stylesheets/elements/_profile.scss
+++ b/app/assets/stylesheets/elements/_profile.scss
@@ -82,10 +82,6 @@
     width: 100%;
     height: auto;
   }
-
-  .simple-view & {
-    box-shadow: none;
-  }
 }
 
 .profile-banner {

--- a/app/assets/stylesheets/elements/_search.scss
+++ b/app/assets/stylesheets/elements/_search.scss
@@ -22,10 +22,6 @@
         display: block;
       }
     }
-
-    .simple-view & {
-      box-shadow: 0 0 0 5px $body-bg;
-    }
   }
 
   label {
@@ -97,10 +93,6 @@
     box-shadow: 0 20px 20px 0 rgba($black, .25), 0 6px 6px 0 rgba($black, .25);
     transition-timing-function: linear;
     transition-delay: 50ms;
-
-    .simple-view & {
-      box-shadow: 0 0 5px $body-bg;
-    }
   }
 }
 

--- a/app/assets/stylesheets/elements/_standout.scss
+++ b/app/assets/stylesheets/elements/_standout.scss
@@ -79,19 +79,6 @@
     }
   }
 
-  .simple-view & {
-    box-shadow: inset 0 0 0 3px $border-color;
-
-    &::before {
-      display: none;
-    }
-
-    img,
-    svg {
-      display: none;
-    }
-  }
-
   p {
     margin: .5rem 0 1rem;
   }

--- a/app/assets/stylesheets/elements/_user-block.scss
+++ b/app/assets/stylesheets/elements/_user-block.scss
@@ -13,10 +13,6 @@
     margin-top: 0;
     margin-left: auto;
   }
-
-  .simple-view & {
-    color: $text-color;
-  }
 }
 
 .user-block__action {

--- a/app/assets/stylesheets/elements/_well.scss
+++ b/app/assets/stylesheets/elements/_well.scss
@@ -23,10 +23,6 @@
   a {
     text-decoration: none;
   }
-
-  .simple-view & {
-    box-shadow: inset 0 0 0 2px $border-color;
-  }
 }
 
 .well__content {

--- a/app/assets/stylesheets/general/_form.scss
+++ b/app/assets/stylesheets/general/_form.scss
@@ -37,16 +37,8 @@
       line-height: 1.5em;
     }
 
-    .simple-view & {
-      box-shadow: 0 0 0 5px $body-bg;
-    }
-
     .high-contrast & {
       font-weight: normal;
-    }
-
-    .high-contrast.simple-view & {
-      box-shadow: 0 0 0 5px var(--bg-darker);
     }
   }
 

--- a/app/assets/stylesheets/general/_general.scss
+++ b/app/assets/stylesheets/general/_general.scss
@@ -18,10 +18,6 @@ body {
   color: $text-color;
   overflow-x: hidden;
 
-  &.simple-view {
-    background: $body-bg;
-  }
-
   &.high-contrast {
     background: darken($body-bg, 5%);
   }
@@ -50,10 +46,6 @@ hr {
 
   &.small {
     margin: $margin / 2 0;
-  }
-
-  .simple-view & {
-    height: 2px;
   }
 }
 

--- a/app/assets/stylesheets/logged_in_user/_chart.scss
+++ b/app/assets/stylesheets/logged_in_user/_chart.scss
@@ -17,10 +17,6 @@
     opacity: .45;
     background: $black;
     box-shadow: 0 0 2rem 2rem $black;
-
-    .simple-view & {
-      display: none;
-    }
   }
 }
 

--- a/app/assets/stylesheets/wiki/_search.scss
+++ b/app/assets/stylesheets/wiki/_search.scss
@@ -20,10 +20,6 @@
       left: 6rem;
       width: calc(100% - 12rem);
     }
-
-    .simple-view & {
-      display: none;
-    }
   }
 
   input:not([type="submit"]) {

--- a/app/controllers/accessibility_controller.rb
+++ b/app/controllers/accessibility_controller.rb
@@ -20,6 +20,6 @@ class AccessibilityController < ApplicationController
 
   private
   def user_params
-    params.require(:user).permit(:high_contrast, :large_fonts, :simple_view, :pagination_type)
+    params.require(:user).permit(:high_contrast, :large_fonts, :pagination_type)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,6 +1,6 @@
 module UsersHelper
   def accessibility_settings
-    "#{ "simple-view" if current_user.simple_view? } #{ "high-contrast" if current_user.high_contrast? } #{ "large-fonts" if current_user.large_fonts? }"
+    "#{ "high-contrast" if current_user.high_contrast? } #{ "large-fonts" if current_user.large_fonts? }"
   end
 
   def is_arbiter?(user)

--- a/app/views/accessibility/edit.html.erb
+++ b/app/views/accessibility/edit.html.erb
@@ -29,16 +29,6 @@
     </p>
   </div>
 
-  <div class="well well--dark mb-1/4">
-    <%= button_to t("accessibility.edit.simple_view.label"), update_accessibility_path, method: :patch, params: { user: { simple_view: !current_user.simple_view } },
-                  class: "switch__input",
-                  form_class: "switch #{ "switch--active" if current_user.simple_view }" %>
-
-    <p class="form-hint mt-0 mb-0">
-      <%= t "accessibility.edit.simple_view.description" %>
-    </p>
-  </div>
-
   <div class="well well--dark block">
     <h4 class="mt-0 mb-1/4 text-base"><%= t "accessibility.edit.pagination_type.title" %></h4>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -26,7 +26,6 @@
     <th><%= link_to "Veri?", admin_users_path(where: "verified") %></th>
     <th><%= link_to "HC?", admin_users_path(where: "high_contrast") %></th>
     <th><%= link_to "Lg?", admin_users_path(where: "large_fonts") %></th>
-    <th><%= link_to "Spl?", admin_users_path(where: "simple_view") %></th>
     <th>Posts</th>
     <th>Cmts</th>
     <th>Fvs</th>
@@ -47,7 +46,6 @@
       <td><%= "✔" if user.verified? %></td>
       <td><%= "✔" if user.high_contrast? %></td>
       <td><%= "✔" if user.large_fonts? %></td>
-      <td><%= "✔" if user.simple_view? %></td>
       <td><%= user.posts.count %></td>
       <td><%= user.comments.count %></td>
       <td><%= user.favorites.count %></td>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,7 +3,7 @@
 
 <main class="top-offset">
   <% unless params[:page] %>
-    <h2 class="mt-1/2 <%= "text-black" unless current_user.present? && current_user.simple_view? %>">
+    <h2 class="mt-1/2">
       <%= inline_svg_tag "icons/icon-onfire.svg", class: "title-icon" %>
       <%= t(".on_fire.title_html") %>
     </h2>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,7 +3,7 @@
 
 <main class="top-offset">
   <% unless params[:page] %>
-    <h2 class="mt-1/2">
+    <h2 class="mt-1/2 text-black">
       <%= inline_svg_tag "icons/icon-onfire.svg", class: "title-icon" %>
       <%= t(".on_fire.title_html") %>
     </h2>

--- a/db/migrate/20220818092440_remove_simple_view_from_users.rb
+++ b/db/migrate/20220818092440_remove_simple_view_from_users.rb
@@ -1,5 +1,5 @@
 class RemoveSimpleViewFromUsers < ActiveRecord::Migration[6.1]
   def change
-    remove_column :users, :simple_view
+    remove_column :users, :simple_view, :boolean
   end
 end

--- a/db/migrate/20220818092440_remove_simple_view_from_users.rb
+++ b/db/migrate/20220818092440_remove_simple_view_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveSimpleViewFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :simple_view
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_29_105736) do
+ActiveRecord::Schema.define(version: 2022_08_18_092440) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -282,7 +282,6 @@ ActiveRecord::Schema.define(version: 2022_07_29_105736) do
     t.string "provider_profile_image"
     t.boolean "high_contrast", default: false
     t.boolean "large_fonts", default: false
-    t.boolean "simple_view", default: false
     t.integer "level", default: 0
     t.boolean "verified", default: false
     t.string "nice_url"


### PR DESCRIPTION
The simple view is super broken and the site is unusable with it turned on. Maintaining it is not worth the effort as hardly anyone ever used it and it's purpose isn't clear. What it is trying to do should instead be done via other ways as having to toggle it isn't a good experience. 