### PR TITLE
feat: Make expiry notification copy more accurate

### DIFF
--- a/lib/tasks/notify_expiry.rake
+++ b/lib/tasks/notify_expiry.rake
@@ -15,9 +15,10 @@ task :notify_expiry => :environment do
           unless has_notification_been_send
             Notification.create(
               content:
-                "==⚠ The Code for **\"#{ post.title }\"** has expired.==
-                **Workshop Codes in Overwatch expire after 6 months**. After this the code will no longer function and **your code will be lost**.
-                Your code is now most likely lost. If you saved a Code Snippet (Either on Workshop.codes or somewhere else) you can generate a new code by copy and pasting the snippet in Overwatch.",
+                "==⚠ The Code for **\"#{ post.title }\"** may have expired.==
+                **Workshop Codes in Overwatch may expire after 6 months**. If a code expires, **your work will be lost**.
+                You can check if a code has expired by attempting to import it in-game. If you receive an error, your code has expired.
+                In the event that your code expires, you can recover it via by copy and pasting a Code Snippet (stored either on Workshop.codes or somewhere else) in Overwatch.",
               go_to: "#{ post_path(nil, post.code) }",
               user_id: post.user.id,
               content_type: :has_expired,
@@ -32,9 +33,9 @@ task :notify_expiry => :environment do
           unless has_notification_been_send
             Notification.create(
               content:
-                "==⚠ The Code for **\"#{ post.title }\"** will soon expire.==
-                **Workshop Codes in Overwatch expire after 6 months**. After this the code will no longer function and **your code will be lost**.
-                Make sure to generate a new code and update it here to prevent losing your Workshop Item forever.",
+                "==⚠ The Code for **\"#{ post.title }\"** may soon expire.==
+                **Workshop Codes in Overwatch may expire after 6 months**. If your code expires, then this code will no longer function and **your code will be lost**.
+                Make sure to renew your code by importing it and uploading it to the same code (see [this article](https://workshop.codes/wiki/articles/uploading+new+content+to+existing+import+code) for more information).",
               go_to: "#{ post_path(nil, post.code) }",
               user_id: post.user.id,
               content_type: :will_expire,


### PR DESCRIPTION
The previous expiry notification copy was inaccurate due to updates in the Overwatch custom game code expiration system. This PR updates the copy to reflect that.
