### PR TITLE
refactor: Remove `set_current_user`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,3 @@
-module Current
-  thread_mattr_accessor :user
-end
-
 class ApplicationController < ActionController::Base
   include ApplicationHelper
   include ActivitiesHelper
@@ -14,7 +10,6 @@ class ApplicationController < ActionController::Base
   before_action :reject_if_banned
   before_action :redirect_non_www, if: -> { Rails.env.production? }
   before_action :redirect_default_locale
-  around_action :set_current_user
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :handle_failed_authenticity_token
   rescue_from AbstractController::ActionNotFound, with: :render_404
@@ -54,13 +49,6 @@ class ApplicationController < ActionController::Base
       @current_user = nil
     end
     @current_user
-  end
-
-  def set_current_user
-    Current.user = current_user
-    yield
-  ensure
-    Current.user = nil
   end
 
   helper_method :search_terms


### PR DESCRIPTION
The controller action `set_current_user` was originally introduced in commit 05369c1a1a29b3d2f71c4a486017eeb577ad2e84 to perform a `nice_url` check, but has since been replaced with a differing check against the record itself in e40c55e77221142ab26ba7414749f4cf8c5697a7.

Thus, this action is no longer necessary and only contributes to clogging up stacktraces in our automated tooling.
