### PR TITLE
feat: Add html endpoint to wiki dictionary

### DIFF
--- a/app/controllers/wiki/dictionary_controller.rb
+++ b/app/controllers/wiki/dictionary_controller.rb
@@ -10,7 +10,7 @@ class Wiki::DictionaryController < Wiki::BaseController
     @dictionary = merged_array.map { |a| a[1]["en-US"] }
 
     respond_to do |format|
-      format.html { render "wiki/dictionary/index.html.erb" }
+      format.html { render "wiki/dictionary/index.html.erb" } # Automatic path doesn't work, possibly because of no plurals
       format.json {
         set_request_headers
         render json: @dictionary.to_json, layout: false

--- a/app/controllers/wiki/dictionary_controller.rb
+++ b/app/controllers/wiki/dictionary_controller.rb
@@ -1,4 +1,6 @@
 class Wiki::DictionaryController < Wiki::BaseController
+  add_breadcrumb "Dictionary", :wiki_dictionary_path
+
   def index
     @actions = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "actions.yml")))
     @values = YAML.load(File.read(Rails.root.join("config/arrays/wiki", "values.yml")))
@@ -7,8 +9,13 @@ class Wiki::DictionaryController < Wiki::BaseController
 
     @dictionary = merged_array.map { |a| a[1]["en-US"] }
 
-    set_request_headers
-    render json: @dictionary.to_json, layout: false
+    respond_to do |format|
+      format.html { render "wiki/dictionary/index.html.erb" }
+      format.json {
+        set_request_headers
+        render json: @dictionary.to_json, layout: false
+      }
+    end
   end
 
   private

--- a/app/views/wiki/dictionary/_item.html.erb
+++ b/app/views/wiki/dictionary/_item.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <%= link_to item[1]["en-US"], wiki_article_path(CGI.escape(item[1]["en-US"]).downcase) %>
+</div>

--- a/app/views/wiki/dictionary/index.html.erb
+++ b/app/views/wiki/dictionary/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "Dictionary" %>
+
+<div class="action-header top-offset">
+  <h1 class="mt-0"><strong>Dictionary</strong></h1>
+</div>
+
+<h2><strong>Actions</strong></h2>
+<%= render collection: @actions.sort_by { |key, content| content["en-US"] }.to_h, partial: "item" %>
+
+<h2><strong>Values</strong></h2>
+<%= render collection: @values.sort_by { |key, content| content["en-US"] }.to_h, partial: "item" %>


### PR DESCRIPTION
This PR adds a quick and dirty HTML endpoint to the already existing `/wiki/dictionary` json endpoint. The code isn't the nicest ever, but it's meant to be fairly rudimentary and so I'd rather not spend too much time on it.

Each item is generated from the actions and values .yaml files. Their links _should_ always match up, even though they aren't directly compared. Old article urls still redirect to new ones in case any article was renamed.

![image](https://user-images.githubusercontent.com/12848235/191142314-ad1213a4-8a25-4d1b-a326-7fce82dc43d2.png)
