### PR TITLE
fix: Legacy JSON redirect

### DIFF
--- a/app/controllers/filter_controller.rb
+++ b/app/controllers/filter_controller.rb
@@ -4,8 +4,8 @@ class FilterController < ApplicationController
     filtered_params = params.permit([:category, :code, :hero, :map, :from, :to, :sort, :expired, :author, :players, :language, :search, :page])
     respond_to do |format|
       format.html   { redirect_to filter_path(filtered_params), status: :moved_permanently }
-      format.js     { redirect_to filter_path(filtered_params), status: :moved_permanently }
-      format.json   { redirect_to filter_path(filtered_params), status: :moved_permanently }
+      format.js     { head :moved_permanently, location: filter_path(params: filtered_params, format: :js) }
+      format.json   { head :moved_permanently, location: filter_path(params: filtered_params, format: :json) }
     end
   end
 

--- a/spec/requests/search_urls_spec.rb
+++ b/spec/requests/search_urls_spec.rb
@@ -24,7 +24,12 @@ RSpec.describe "SearchUrls", type: :request do
 
       expect(response.content_type).to start_with("application/json")
       expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to(filter_path(params: { hero: "reinhardt" }))
+      expect(response).to redirect_to(filter_path(params: { hero: "reinhardt" }, format: :json))
+
+      follow_redirect!
+
+      expect(response.content_type).to start_with("application/json")
+      expect(response).to have_http_status(:ok)
     end
 
     it "redirects GET /search with no parameters to home" do


### PR DESCRIPTION
This PR fixes the format of a request (e.g. "application/json") not being preserved when redirecting from legacy search paths
