### PR TITLE
refactor: Move latest posts to their own action

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,16 +30,11 @@ class PostsController < ApplicationController
 
   def index
     @hot_posts = Post.includes(:user).select_overview_columns.public?.where("hotness > 1").order("hotness DESC").limit(10) unless params[:page].present?
-    @posts = Post.includes(:user).select_overview_columns.public?.order(created_at: :desc).page params[:page]
+    latest_posts
+  end
 
-    respond_to do |format|
-      format.html
-      format.js { render "posts/infinite_scroll_posts" }
-      format.json {
-        set_request_headers
-        render json: @posts
-      }
-    end
+  def latest
+    latest_posts
   end
 
   def show
@@ -231,6 +226,19 @@ class PostsController < ApplicationController
 
   def set_post
     @post = Post.find_by_code(params[:code])
+  end
+
+  def latest_posts
+    @posts = Post.includes(:user).select_overview_columns.public?.order(created_at: :desc).page params[:page]
+
+    respond_to do |format|
+      format.html
+      format.js { render "posts/infinite_scroll_posts" }
+      format.json {
+        set_request_headers
+        render json: @posts
+      }
+    end
   end
 
   def set_post_images

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -6,7 +6,7 @@
 
   <div class="header__content" data-role="navigation">
     <nav class="navigation">
-      <%= link_to t("navigation.recent"), posts_path(1), class: "navigation__item #{ "navigation__item--active" if controller_name == "posts" && action_name == "index" && params[:page] }" %>
+      <%= link_to t("navigation.recent"), latest_path, class: "navigation__item #{ "navigation__item--active" if controller_name == "posts" && action_name == "latest" }" %>
       <%= link_to t("navigation.on_fire"), on_fire_path, class: "navigation__item #{ "navigation__item--active" if controller_name == "on_fire" }" %>
       <%= link_to t("navigation.wiki"), wiki_root_path, class: "navigation__item #{ "navigation__item--active" if is_wiki? }" %>
       <%= link_to inline_svg_tag("discord.svg"), "https://discord.gg/DdxsQRD", target: "_blank", rel: "noreferrer noopener", class: "navigation__item mt-1/4 mbl:mt-1/8", aria: { label: "Join the Workhsop.codes Discord" } %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,35 +1,25 @@
-<% content_for :page_title, "#{ t("navigation.recent") } | Page #{ params[:page] }" if params[:page] %>
-<% content_for :bg_size, "large" unless params[:page] %>
+<% content_for :bg_size, "large" %>
 
 <main class="top-offset">
-  <% unless params[:page] %>
-    <h2 class="mt-1/2 text-black">
-      <%= inline_svg_tag "icons/icon-onfire.svg", class: "title-icon" %>
-      <%= t(".on_fire.title_html") %>
-    </h2>
+  <h2 class="mt-1/2 text-black">
+    <%= inline_svg_tag "icons/icon-onfire.svg", class: "title-icon" %>
+    <%= t(".on_fire.title_html") %>
+  </h2>
 
-    <%= render "on_fire_carousel" %>
+  <%= render "on_fire_carousel" %>
 
-    <div class="logo-background logo-background--overwatch">
-      <%= render "filter/quick_filter" %>
+  <div class="logo-background logo-background--overwatch">
+    <%= render "filter/quick_filter" %>
 
-      <% if ENV["BANNER_ROOT"] == "OW2" %>
-        <%= render "application/banners/overwatch_2" %>
-      <% end %>
-    </div>
+    <% if ENV["BANNER_ROOT"] == "OW2" %>
+      <%= render "application/banners/overwatch_2" %>
+    <% end %>
+  </div>
 
-    <%= render "user_recommendations" if current_user && current_user.recommended_posts.any? %>
-  <% end %>
+  <%= render "user_recommendations" if current_user && current_user.recommended_posts.any? %>
 
   <div class="action-header">
-    <% if params[:page] %>
-      <h1>
-        <%= t(".recent.title_html") %>
-        <%= tag.small "- Page #{ params[:page] }" if params[:page].to_i > 1 %>
-      </h1>
-    <% else %>
-      <h2 class="mt-1/1"><%= t(".recent.title_html") %></h2>
-    <% end %>
+    <h2 class="mt-1/1"><%= t(".recent.title_html") %></h2>
   </div>
 
   <%= render "posts" %>

--- a/app/views/posts/latest.html.erb
+++ b/app/views/posts/latest.html.erb
@@ -1,0 +1,14 @@
+<% content_for :page_title, "#{ t("navigation.recent") }" %>
+
+<div class="heading">
+  <h1>
+    <% if params[:page] %>
+      <%= t("posts.index.recent.title_html") %>
+      <%= tag.small "- Page #{ params[:page] }" if params[:page].to_i > 1 %>
+    <% else %>
+      <%= t("posts.index.recent.title_html") %>
+    <% end %>
+  </h1>
+</div>
+
+<%= render "posts" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,7 +112,9 @@ Rails.application.routes.draw do
     get "revisions/:id(/:compare_id)", to: "revisions#show", as: "difference"
     get "raw-snippet/:id(.:format)", to: "revisions#raw_snippet", as: "raw_snippet", format: :json
 
-    get "(page/:page)", to: "posts#index"
+    get "latest", to: "posts#latest", as: "latest"
+    get "page/1", to: redirect("/latest", status: 301)
+
     get "search", to: "search#show", as: "filter"
     post "search", to: "search#index", as: "search_post"
     get "(categories/:category)/(heroes/:hero)/(maps/:map)/(from/:from)/(to/:to)/(exclude-expired/:expired)/(overwatch-2/:overwatch_2)/(author/:author)/(players/:players)/(code/:code)/(search/:search)/(sort/:sort)/(language/:language)/(page/:page)", to: "filter#index", constraints: FilterContraints


### PR DESCRIPTION
With the refactor of URLs pagination broke on the homepage. The homepage was always a bit messy in that it was not _just_ the homepage, it was also the latest page in disguise. With this PR latest is moved to it's own action with it's own url `/latest`. A redirect is added for SEO, as `/page/1` is a very popular page.