### PR TITLE
fix: Add missing compiler import

### DIFF
--- a/app/javascript/src/utils/compiler.js
+++ b/app/javascript/src/utils/compiler.js
@@ -1,5 +1,5 @@
 import { templates } from "../lib/templates"
-import { getSettings, getClosingBracket } from "./editor"
+import { getSettings, getClosingBracket, replaceBetween } from "./editor"
 import { sortedItems } from "../stores/editor"
 import { get } from "svelte/store"
 


### PR DESCRIPTION
This PR fixes a missing import in the compiler for the Workshop.codes editor.
