### PR TITLE
feat: Add ability to rename projects

### DIFF
--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -240,13 +240,13 @@
 
     {#if showProjectSettings}
       <div transition:fly={{ duration: 150, y: 20 }} class="dropdown__content dropdown__content--left block w-100" style="width: 200px">
-        <p class="dropdown__item mt-0 mb-0" on:click={() => {
+        <div class="dropdown__item" on:click={() => {
           value = $currentProject.title
           modalType = "rename"
           showModal = true
         }}>
           Rename
-        </p>
+        </div>
         <div class="dropdown__item text-red" on:click={destroyProject}>
           Destroy
         </div>

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -94,14 +94,14 @@
 
   function renameProject() {
     if (!$isSignedIn) {
-      alert("You must be signed in to rename a project");
-      showModal = false;
-      return;
+      alert("You must be signed in to rename a project")
+      showModal = false
+      return
     } else
-        if (!$currentProject) {
-      alert("No project selected? This is probably a bug.");
-      showModal = false;
-      return;
+    if (!$currentProject) {
+      alert("No project selected? This is probably a bug.")
+      showModal = false
+      return
     }
 
     loading = true

--- a/app/javascript/src/lib/alerts.js
+++ b/app/javascript/src/lib/alerts.js
@@ -1,0 +1,37 @@
+export function addAlert(alertText, additionalAlertClasses = []) {
+  const textNode = document.createElement("p")
+  textNode.classList.add("mt-1/16", "mb-1/16")
+  textNode.innerText = alertText
+
+  const closeButton = document.createElement("button", { "data-role": "dismiss-parent" })
+  closeButton.classList.add("button", "button--link", "p-0", "pl-1/16", "pr-1/16")
+  closeButton.dataset.role = "dismiss-parent"
+  closeButton.innerText = "✕"
+
+  function dismissParent(event) {
+    const parent = this.parentNode
+    parent.classList.add("fade-out")
+    setTimeout(() => {
+      parent.remove()
+    }, 500)
+    event.preventDefault()
+  }
+
+  closeButton.addEventListener("click", dismissParent)
+
+  const element = document.createElement("div")
+  element.classList.add("alerts__alert", ...additionalAlertClasses)
+  element.appendChild(textNode)
+  element.appendChild(closeButton)
+
+  const parent = document.querySelector("[data-role~='alerts']")
+  parent.appendChild(element)
+}
+
+export function addAlertWarning(alertText) {
+  addAlert(alertText, ["alerts__alert--warning"])
+}
+
+export function addAlertError(alertText) {
+  addAlert(alertText, ["alerts__alert--error"])
+}


### PR DESCRIPTION
This PR adds an item to the Edit menu which allows the user to rename their project.
![Rename dropdown showcase](https://user-images.githubusercontent.com/10406383/201568432-672e6761-c966-46c3-85cb-7f20503894d8.png)

![Rename modal showcase](https://user-images.githubusercontent.com/10406383/201568383-d09326ed-6d73-4d58-a03c-2de59002ee69.png)

When the user renames their project, they will be shown a notification which informs them that the operation was successful:
![Rename success notification](https://user-images.githubusercontent.com/10406383/201568561-a4c0fe08-dd9d-46dd-b106-3dcc684e8832.png)

