### PR TITLE
fix: Update document title when project is renamed

### DIFF
--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -91,6 +91,9 @@
       return string.toLowerCase().replace(/(^\w{1})|(\s+\w{1})/g, letter => letter.toUpperCase())
     }
   }
+
+  // Updates the tab title if the currentProject's title changes
+  $: document.title = $currentProject?.title !== undefined ? `Editor | ${$currentProject.title} | Workshop.codes Script Editor` : "Workshop.codes Script Editor | Workshop.codes"
 </script>
 
 <svelte:head>

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -93,7 +93,7 @@
   }
 
   // Updates the tab title if the currentProject's title changes
-  $: document.title = $currentProject?.title !== undefined ? `Editor | ${$currentProject.title} | Workshop.codes Script Editor` : "Workshop.codes Script Editor | Workshop.codes"
+  $: document.title = $currentProject?.title !== undefined ? `Editor | ${ $currentProject.title } | Workshop.codes Script Editor` : "Workshop.codes Script Editor | Workshop.codes"
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This PR fixes a minor issue where renaming a project would not update the document title
