### PR TITLE
refactor: Ensure only one source of truth for document title

### DIFF
--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -92,17 +92,9 @@
     }
   }
 
-  // Updates the tab title if the currentProject's title changes
+  // Updates the tab title
   $: document.title = $currentProject?.title !== undefined ? `Editor | ${ $currentProject.title } | Workshop.codes Script Editor` : "Workshop.codes Script Editor | Workshop.codes"
 </script>
-
-<svelte:head>
-  {#if $currentProject}
-    <title>Editor | {$currentProject.title} | Workshop.codes Script Editor</title>
-  {:else}
-  <title>Workshop.codes Script Editor | Workshop.codes</title>
-  {/if}
-</svelte:head>
 
 <div class="editor">
   <div class="editor__top">

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -110,7 +110,10 @@
       .then(data => {
         if (!data) throw Error("Project rename failed")
 
-        $currentProject.title = value
+        $currentProject = {
+          ...$currentProject,
+          title: value
+        }
         showModal = false
 
         addAlert("Project renamed to " + $currentProject.title)


### PR DESCRIPTION
With #210 adding another source of truth for the document title which the `svelte:head` component formerly provided, this PR eliminates the latter. The `svelte:head` component, for reasons not entirely known, does not respond to the updating of the `$currentProject` object, either by alteration of its properties or by reassignment, but the reactive statement does.
