### PR TITLE
fix/ci: GitHub Actions update and .eslintrc.yml fix

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,7 +14,7 @@ overrides:
     processor: svelte3/svelte3
 ignorePatterns:
   - /public
-  - */zez-ui
+  - /**/zez-ui
 rules:
   semi:
     - error

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,14 +1,20 @@
 name: CI
 on: [push, pull_request]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BLIND_INDEX_MASTER_KEY: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
   LOCKBOX_MASTER_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+
 jobs:
   linters:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup System
         run: |
           sudo apt update
@@ -18,7 +24,7 @@ jobs:
         with:
           ruby-version: 3.0.0
           bundler-cache: true
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14"
           check-latest: true
@@ -30,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup System
         run: |
           sudo apt update
@@ -40,7 +46,7 @@ jobs:
         with:
           ruby-version: 3.0.0
           bundler-cache: true
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14"
           check-latest: true
@@ -62,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup System
         run: |
           sudo apt update
@@ -74,7 +80,7 @@ jobs:
           ruby-version: 3.0.0
           bundler-cache: true
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "14"
           check-latest: true


### PR DESCRIPTION
This PR updates GitHub Actions workflows to use non-deprecated versions of actions, as well as cancelling older CI workflows when new commits get pushed.

This PR also fixes an incorrect glob pattern in `.eslintrc.yml`.