### PR TITLE
feat: Replace expiry message with last updated date

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -69,7 +69,7 @@ document.addEventListener("turbolinks:load", function() {
   differenceViewer.render()
   getKoFiValue.render()
   numPlayersSlider.render()
-  timeago.render()
+  timeago.initialize()
 })
 
 document.addEventListener("turbolinks:before-cache", function() {

--- a/app/javascript/src/infinite-scroll.js
+++ b/app/javascript/src/infinite-scroll.js
@@ -1,4 +1,5 @@
 import Rails from "@rails/ujs"
+import * as timeago from "timeago.js"
 
 export function bind() {
   const element = document.querySelector("[data-role='infinite-scroll-marker']")
@@ -66,6 +67,14 @@ function getInfiniteScrollContent(element) {
         element.innerHTML = "Load more"
         element.setAttribute("data-url", requestUrlString)
       }
+
+      // Initialize "Last updated" attribute in newly loaded items
+      const elements = document.querySelectorAll("[data-role~='timeago']")
+      if (elements.length) timeago.render(elements)
+
+      // Don't do live updating (too distracting)
+      const staticElements = Array.from(elements.values()).filter((element) => element.matches("[data-role~='timeago-static']"))
+      if (staticElements.length) staticElements.forEach((element) => timeago.cancel(element))
     },
     error: (error) => {
       progressBar.setValue(1)

--- a/app/javascript/src/infinite-scroll.js
+++ b/app/javascript/src/infinite-scroll.js
@@ -1,5 +1,5 @@
 import Rails from "@rails/ujs"
-import * as timeago from "timeago.js"
+import * as timeago from "./timeago.js"
 
 export function bind() {
   const element = document.querySelector("[data-role='infinite-scroll-marker']")
@@ -68,13 +68,7 @@ function getInfiniteScrollContent(element) {
         element.setAttribute("data-url", requestUrlString)
       }
 
-      // Initialize "Last updated" attribute in newly loaded items
-      const elements = document.querySelectorAll("[data-role~='timeago']")
-      if (elements.length) timeago.render(elements)
-
-      // Don't do live updating (too distracting)
-      const staticElements = Array.from(elements.values()).filter((element) => element.matches("[data-role~='timeago-static']"))
-      if (staticElements.length) staticElements.forEach((element) => timeago.cancel(element))
+      timeago.initialize()
     },
     error: (error) => {
       progressBar.setValue(1)

--- a/app/javascript/src/timeago.js
+++ b/app/javascript/src/timeago.js
@@ -1,6 +1,6 @@
 import * as timeago from "timeago.js"
 
-export function render() {
+export function initialize() {
   const elements = document.querySelectorAll("[data-role~='timeago']")
 
   if (elements.length) timeago.render(elements)

--- a/app/javascript/src/timeago.js
+++ b/app/javascript/src/timeago.js
@@ -1,7 +1,10 @@
 import * as timeago from "timeago.js"
 
 export function render() {
-  const elements = document.querySelectorAll("[data-role='timeago']")
+  const elements = document.querySelectorAll("[data-role~='timeago']")
 
   if (elements.length) timeago.render(elements)
+
+  const staticElements = Array.from(elements.values()).filter((element) => element.matches("[data-role~='timeago-static']"))
+  if (staticElements.length) staticElements.forEach((element) => timeago.cancel(element))
 }

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -29,17 +29,15 @@
           <% end %>
         </div>
 
-        <% if post.expired? %>
-          <div class="item__details-item">
-            <div class="tooltip">
-              ⚠ <%= t("post.expired.title") %>
+        <div class="item__details-item" title="<%= t("post.updated") %>: <%= post.last_revision_created_at %>">
+          <%= t("post.updated") %>:
 
-              <div class="tooltip__content">
-                <%= t("post.expired.tooltip_html") %>
-              </div>
-            </div>
-          </div>
-        <% end %>
+          <% if post.last_revision_created_at.blank? %>
+            Draft
+          <% else %>
+            <time data-role="timeago timeago-static" datetime="<%= post.last_revision_created_at %>"></time>
+          <% end %>
+        </div>
       </div>
     <% end %>
   </article>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,6 +272,7 @@ en:
     expired:
       title: Possibly expired
       tooltip_html: <strong>This code is over 6 months old.</strong> This might mean the code has expired and will no longer function.
+    updated: Last updated
 
   comments:
     title: Comments

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -230,6 +230,7 @@ ko:
     expired:
       title: 만료되었을 수 있음
       tooltip_html: <strong>이 코드는 6 개월이 넘었습니다.</strong> 이는 코드가 만료되어 더 이상 작동하지 않음을 의미 할 수 있습니다.
+    updated: 최종 업데이트
 
   comments:
     title: 코멘트


### PR DESCRIPTION
This PR replaces the expiry message (pictured below),
![A listing for an example Workshop.codes post with a expiry warning](https://user-images.githubusercontent.com/10406383/207213260-7a1253d4-bcfe-44bc-9339-e15d1cf47b8e.png)
with a field showing the last revision date of the post (pictured below)
![A listing for an example Workshop.codes post with the new last revision date field](https://user-images.githubusercontent.com/10406383/207213472-5249df51-07a1-4d77-aa81-615125c26e1b.png)

KNOWN ISSUES:
- The current timeago render does not consider the user's current locale

This PR resolves #224.