### PR TITLE
ci(Cucumber): Use pre-installed non-Snap firefox

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -73,7 +73,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get install libsqlite3-dev
-          sudo apt-get install firefox
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -93,4 +92,4 @@ jobs:
       - name: Cucumber
         run: |
           bundle exec rake db:test:prepare
-          TMPDIR=$HOME/tmp bundle exec cucumber
+          bundle exec cucumber

--- a/features/support/setup.rb
+++ b/features/support/setup.rb
@@ -8,28 +8,6 @@ World(FactoryBot::Syntax::Methods)
 # Enable mocking the OmniAuth flow
 OmniAuth.config.test_mode = true
 
-# HACK: EXTREMELY ugly
-# Because Snap-packaged Firefox is sandboxed and cannot see into
-# the /tmp directory, we need to make a clean tmp directory under the
-# user's home to store the profiles
-
-# Unfortunately, this means that the test runner must set the
-# environment variable `TMPDIR` to `$HOME/tmp` manually, either by
-# a bash command somewhat like the following:
-# ```
-# #!bin/bash
-# TMPDIR=$HOME/tmp bundle exec rake cucumber`
-# ```
-# or otherwise
-
-BeforeAll do
-  Dir.mkdir(File.join(Dir.home, "tmp")) unless File.exist?(File.join(Dir.home, "tmp"))
-end
-
-AfterAll do
-  FileUtils.remove_dir(File.join(Dir.home, "tmp"), true)
-end
-
 Capybara.javascript_driver = :selenium_headless
 
 # Set the global random seed for reproducible test runs


### PR DESCRIPTION
This PR undoes the changes made in #227.

As it turns out, GitHub Actions runners actually come with a non-Snap Firefox installation, which is perfectly capable of reading the `/tmp` directory. All we need to do is avoid updating Firefox to the Snap version.