### PR TITLE
refactor/fix: Prevent unintended styling under `.standout` elements

### DIFF
--- a/app/assets/stylesheets/elements/_standout.scss
+++ b/app/assets/stylesheets/elements/_standout.scss
@@ -88,25 +88,25 @@
       background: var(--standout-color, #{$overwatch-2});
     }
   }
+}
 
-  &__subtitle {
-    color: $text-color-dark;
-  }
+.standout__subtitle {
+  color: $text-color-dark;
+}
 
-  &__heading {
-    color: var(--standout-color, #{$overwatch-2});
-  }
+.standout__heading {
+  color: var(--standout-color, #{$overwatch-2});
+}
 
-  &__description {
-    display: none;
-    margin-top: $margin / 8;
-    font-size: $font-size-small;
-    line-height: 1.25em;
-    text-align: left;
+.standout__description {
+  display: none;
+  margin-top: $margin / 8;
+  font-size: $font-size-small;
+  line-height: 1.25em;
+  text-align: left;
 
-    @include media-min(md) {
-      display: block;
-    }
+  @include media-min(md) {
+    display: block;
   }
 }
 

--- a/app/assets/stylesheets/elements/_standout.scss
+++ b/app/assets/stylesheets/elements/_standout.scss
@@ -108,12 +108,6 @@
       display: block;
     }
   }
-
-  a[id] img {
-    background: darken($bg-dark, 10%);
-    color: $text-color-dark;
-    font-size: 12px;
-  }
 }
 
 .standout-grid {

--- a/app/assets/stylesheets/elements/_standout.scss
+++ b/app/assets/stylesheets/elements/_standout.scss
@@ -89,15 +89,15 @@
     }
   }
 
-  small {
+  &__subtitle {
     color: $text-color-dark;
   }
 
-  h3 {
+  &__heading {
     color: var(--standout-color, #{$overwatch-2});
   }
 
-  span {
+  &__description {
     display: none;
     margin-top: $margin / 8;
     font-size: $font-size-small;

--- a/app/views/application/banners/_editor.html.erb
+++ b/app/views/application/banners/_editor.html.erb
@@ -2,49 +2,49 @@
 
 <div class="standout-grid">
   <%= link_to editor_path, class: "standout standout--compact standout--editor", style: "--standout-color: var(--primary)", target: "_blank" do %>
-    <h3 class="mt-0 mb-0">
+    <h3 class="standout__heading mt-0 mb-0">
       <strong>Workshop.codes Editor</strong>
     </h3>
 
-    <small class="block">By Workshop.codes</small>
+    <small class="standout__subtitle block">By Workshop.codes</small>
 
-    <span>
+    <span class="standout__description">
       A familiar syntax with new features such as folder, mixins, automatic variables, and more. All from within your browser!
     </span>
   <% end %>
 
   <%= link_to zez_ui_path, class: "standout standout--compact standout--editor", target: "_blank", rel: "noreferrer noopener" do %>
-    <h3 class="mt-0 mb-0">
+    <h3 class="standout__heading mt-0 mb-0">
       <strong>Zez's Workshop UI</strong>
     </h3>
 
-    <small class="block">By Zezombye</small>
+    <small class="standout__subtitle block">By Zezombye</small>
 
-    <span>
+    <span class="standout__description">
       The UI you know and love is back, now with built-in optimization!
     </span>
   <% end %>
 
   <%= link_to "https://github.com/Zezombye/overpy", class: "standout standout--compact standout--editor", style: "--standout-color: #ffdd6c", target: "_blank", rel: "noreferrer noopener" do %>
-    <h3 class="mt-0 mb-0">
+    <h3 class="standout__heading mt-0 mb-0">
       <strong>OverPy</strong>
     </h3>
 
-    <small class="block">By Zezombye</small>
+    <small class="standout__subtitle block">By Zezombye</small>
 
-    <span>
+    <span class="standout__description">
       Code your gamemodes with modern development practices and break the limitations of the workshop UI with features such as multiple files, macros, switches, enums, optimizations, string splitting, better syntax, etc.
     </span>
   <% end %>
 
   <%= link_to "https://github.com/ItsDeltin/Overwatch-Script-To-Workshop", class: "standout standout--compact standout--editor", style: "--standout-color: #69cfed", target: "_blank", rel: "noreferrer noopener" do %>
-    <h3 class="mt-0 mb-0">
+    <h3 class="standout__heading mt-0 mb-0">
       <strong>Deltin's Script To Workshop</strong>
     </h3>
 
-    <small class="block">By Deltin</small>
+    <small class="standout__subtitle block">By Deltin</small>
 
-    <span>
+    <span class="standout__description">
       Ostw is an abstraction over the workshop allowing programming features such as data collections in the form of structs or classes, object oriented programming, and lambdas (or closures).
     </span>
   <% end %>


### PR DESCRIPTION
This PR fixes an issue where certain parts of the site which use the `standout` CSS class had unintentional/unintuitive styling applied. The issue arose due to styling initially added to highlight Workshop alternatives on the front page targeting generic elements instead of elements with certain classes. This PR changes the styling for the front page to use specific classes.

Example of broken styling:
![image](https://user-images.githubusercontent.com/10406383/212254170-3acc57e4-5191-4b5a-a801-e52e313adfd6.png)

Inspector showing the specificity override from frontpage styling:
![](https://i.imgur.com/qrIj9hw.png)

Fixed styling:
![](https://i.imgur.com/gEsbk6V.png)

Inspector showing lack of styling pollution:
![image](https://user-images.githubusercontent.com/10406383/212254971-bfd4c4f5-8a1f-4b86-a233-1d5063c478c6.png)
