### PR TITLE
feat: Show info bubble in code input for users who have not created any posts

### DIFF
--- a/app/assets/stylesheets/elements/_bubble.scss
+++ b/app/assets/stylesheets/elements/_bubble.scss
@@ -1,0 +1,42 @@
+@keyframes fly-in-bubble {
+  from {
+    transform: translateY(105%);
+    opacity: 0;
+  }
+}
+
+.bubble {
+  position: absolute;
+  bottom: -#{$margin / 8};
+  left: 0;
+  transform: translateY(100%);
+  width: 100%;
+  padding: $margin / 4;
+  border-radius: $border-radius / 2;
+  background: $orange;
+  box-shadow: $shadow;
+  z-index: 10;
+  text-align: left;
+  font-size: $font-size-small;
+  color: $pure-white;
+  animation: fly-in-bubble 200ms forwards;
+
+  &::before {
+    $size: 1rem;
+    content: "";
+    display: block;
+    position: absolute;
+    left: 1rem;
+    top: $size * -0.5;
+    transform: rotate(45deg);
+    height: $size;
+    width: $size;
+    background: $orange;
+    border-top-left-radius: $border-radius / 4;
+  }
+
+  hr {
+    margin: $margin / 4 0;
+    background: rgba($pure-white, 0.35);
+  }
+}

--- a/app/assets/stylesheets/elements/_bubble.scss
+++ b/app/assets/stylesheets/elements/_bubble.scss
@@ -34,11 +34,6 @@
     border-top-left-radius: $border-radius / 4;
   }
 
-  hr {
-    margin: $margin / 4 0;
-    background: rgba($pure-white, 0.35);
-  }
-
   &--warning {
     background: $orange;
     color: $pure-white;
@@ -47,4 +42,9 @@
       background: $orange;
     }
   }
+}
+
+.bubble__separator {
+  margin: $margin / 4 0;
+  background: rgba($pure-white, 0.35);
 }

--- a/app/assets/stylesheets/elements/_bubble.scss
+++ b/app/assets/stylesheets/elements/_bubble.scss
@@ -13,12 +13,11 @@
   width: 100%;
   padding: $margin / 4;
   border-radius: $border-radius / 2;
-  background: $orange;
+  background: lighten($bg-dark, 5%);
   box-shadow: $shadow;
   z-index: 10;
   text-align: left;
   font-size: $font-size-small;
-  color: $pure-white;
   animation: fly-in-bubble 200ms forwards;
 
   &::before {
@@ -31,12 +30,21 @@
     transform: rotate(45deg);
     height: $size;
     width: $size;
-    background: $orange;
+    background: lighten($bg-dark, 5%);
     border-top-left-radius: $border-radius / 4;
   }
 
   hr {
     margin: $margin / 4 0;
     background: rgba($pure-white, 0.35);
+  }
+
+  &--warning {
+    background: $orange;
+    color: $pure-white;
+
+    &::before {
+      background: $orange;
+    }
   }
 }

--- a/app/assets/stylesheets/elements/_show-on-focus-within.scss
+++ b/app/assets/stylesheets/elements/_show-on-focus-within.scss
@@ -1,0 +1,7 @@
+.show-on-focus-within__content {
+  display: none;
+
+  .show-on-focus-within:focus-within & {
+    display: block;
+  }
+}

--- a/app/views/posts/form/_form.html.erb
+++ b/app/views/posts/form/_form.html.erb
@@ -12,7 +12,7 @@
           <%= form.text_field :code, class: "form-input form-input--large", placeholder: t("posts.form.code"), data: { action: "reveal-on-difference", original: @post.code }, autocomplete: "off" %>
 
           <% if current_user.posts.none? %>
-            <div class="bubble show-on-focus-within__content">
+            <div class="bubble bubble--warning show-on-focus-within__content">
               Not sure where to get a code? <br>
               <%= link_to "Get started here", "https://workshop.codes/wiki/articles/uploading+new+content+to+existing+import+code", class: "button button--small button--light text-orange mt-1/8", target: "_blank" %>
               <hr />

--- a/app/views/posts/form/_form.html.erb
+++ b/app/views/posts/form/_form.html.erb
@@ -15,7 +15,7 @@
             <div class="bubble bubble--warning show-on-focus-within__content">
               Not sure where to get a code? <br>
               <%= link_to "Get started here", "https://workshop.codes/wiki/articles/uploading+new+content+to+existing+import+code", class: "button button--small button--light text-orange mt-1/8", target: "_blank" %>
-              <hr />
+              <hr class="bubble__separator" />
               Looking to get started with the Workshop? <br>
               <%= link_to "Check out our Editor", editor_path, class: "button button--small button--light text-orange mt-1/8", target: "_blank" %>
             </div>

--- a/app/views/posts/form/_form.html.erb
+++ b/app/views/posts/form/_form.html.erb
@@ -8,8 +8,18 @@
           <%= form.text_field :title, class: "form-input form-input--large", placeholder: t("posts.form.title") %>
         </div>
 
-        <div class="form-group sm:mt-0">
+        <div class="form-group relative show-on-focus-within sm:mt-0">
           <%= form.text_field :code, class: "form-input form-input--large", placeholder: t("posts.form.code"), data: { action: "reveal-on-difference", original: @post.code }, autocomplete: "off" %>
+
+          <% if current_user.posts.none? %>
+            <div class="bubble show-on-focus-within__content">
+              Not sure where to get a code? <br>
+              <%= link_to "Get started here", "https://workshop.codes/wiki/articles/uploading+new+content+to+existing+import+code", class: "button button--small button--light text-orange mt-1/8", target: "_blank" %>
+              <hr />
+              Looking to get started with the Workshop? <br>
+              <%= link_to "Check out our Editor", editor_path, class: "button button--small button--light text-orange mt-1/8", target: "_blank" %>
+            </div>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/posts/validation.js.erb
+++ b/app/views/posts/validation.js.erb
@@ -12,7 +12,7 @@
     <% @post.errors.each do |error| %>
       elements = document.querySelectorAll("[name*='post[<%= error.attribute %>']")
       elements.forEach(element => {
-        const formGroup = element.closest(".form-group")
+        const formGroup = element.closest("[class^='form-group']")
         formGroup.classList.add("field_with_errors")
 
         const tabContent = element.closest("[data-tab]")


### PR DESCRIPTION
To reduce the amount of posts from confused users who aren't exactly sure what to do we show a popup when focusing the code input. This popup provides two options, one links to the wiki article on how to generate a code, the second option links to the workshop.codes editor.

The popup is shown entirely with css and is shown while focusing the input. It being just css is not really relevant, but it makes it easy to use.

The popup is only shown to users who have not yet created any posts. With this we assume that those who have created posts (that are not destroyed by us) know what they are doing.

This PR also includes a fix for validation errors caused by the number of players slider, preventing it from properly showing the error status in the tabs.

![code-bubble](https://user-images.githubusercontent.com/12848235/212569608-fb14788d-2ce1-47f3-a58c-2af512ac1fbf.gif)

