### PR TITLE
feat: Search/replace all in w.c editor

### DIFF
--- a/app/assets/stylesheets/editor/_matches.scss
+++ b/app/assets/stylesheets/editor/_matches.scss
@@ -1,22 +1,31 @@
 .matches {
-  padding: $margin / 8 0;
   margin-top: $margin / 4;
-  border-radius: $border-radius / 2;
-  background: darken($bg-dark, 5%);
-  box-shadow: $shadow;
-  overflow: hidden;
+
+  &--dropdown {
+    padding: $margin / 8 0;
+    border-radius: $border-radius / 2;
+    background: darken($bg-dark, 5%);
+    box-shadow: $shadow;
+    overflow: hidden;
+  }
 }
 
 .matches__item {
-  padding: $margin / 8 $margin / 4;
+  padding: $margin / 8 0;
   cursor: pointer;
+
+  .matches--dropdown & {
+    padding: $margin / 8 $margin / 4;
+  }
 
   &:hover {
     background: darken($bg-dark, 7.5%);
+    box-shadow: $margin 0 0 darken($bg-dark, 7.5%), $margin * -1 0 0 darken($bg-dark, 7.5%);
   }
 
   &--active {
     background: $bg-darker;
+    box-shadow: $margin 0 0 $bg-darker, $margin * -1 0 0 $bg-darker;
     color: $white;
   }
 }

--- a/app/javascript/src/components/editor/CodeMirror.svelte
+++ b/app/javascript/src/components/editor/CodeMirror.svelte
@@ -19,6 +19,7 @@
 
   $: if ($currentProjectUUID) $editorStates = {}
   $: if ($currentItem.id != currentId && view) updateEditorState()
+  $: if ($currentItem.forceUpdate) updateEditorState()
 
   onMount(() => {
     view = new EditorView({
@@ -29,7 +30,8 @@
   onDestroy(() => $editorStates = {})
 
   function updateEditorState() {
-    if (currentId) $editorStates[currentId] = view.state
+    if (currentId && !$currentItem.forceUpdate) $editorStates[currentId] = view.state
+    if ($currentItem.forceUpdate) $currentItem = { ...$currentItem, forceUpdate: false }
 
     currentId = $currentItem.id
 

--- a/app/javascript/src/components/editor/Editor.svelte
+++ b/app/javascript/src/components/editor/Editor.svelte
@@ -12,6 +12,7 @@
   import Empty from "./Empty.svelte"
   import Settings from "./Settings.svelte"
   import ItemFinder from "./ItemFinder.svelte"
+  import FindReplaceAll from "./FindReplaceAll.svelte"
   import * as logo from "../../../../assets/images/logo.svg"
 
   export let values
@@ -136,9 +137,15 @@
   {#if $currentProjectUUID}
     <div class="editor__aside">
       <div class="editor__scrollable">
-        <div class="p-1/4 pt-0">
+        <div class="pr-1/4 pl-1/4">
           <ItemFinder />
+
+          <div class="mt-1/16">
+            <FindReplaceAll />
+          </div>
         </div>
+
+        <hr class="mt-1/4 mb-1/4" />
 
         <EditorAside />
       </div>

--- a/app/javascript/src/components/editor/EditorAside.svelte
+++ b/app/javascript/src/components/editor/EditorAside.svelte
@@ -15,6 +15,10 @@
 
 <svelte:window on:keydown={keydown} />
 
+<div class="pl-1/4 pr-1/4 pb-1/8">
+  <strong>Files</strong>
+</div>
+
 <div bind:this={element} tabindex="0">
   <EditorList />
 

--- a/app/javascript/src/components/editor/EditorAside.svelte
+++ b/app/javascript/src/components/editor/EditorAside.svelte
@@ -16,7 +16,7 @@
 <svelte:window on:keydown={keydown} />
 
 <div class="pl-1/4 pr-1/4 pb-1/8">
-  <strong>Files</strong>
+  <strong>Items</strong>
 </div>
 
 <div bind:this={element} tabindex="0">

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -30,7 +30,7 @@
       i.type == "item" &&
       i.content.indexOf(value) != -1)
 
-    const regex = new RegExp(value, "g")
+    const regex = new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), "g")
 
     itemMatches = filteredItems.map(i => {
       const contentMatches = []

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -4,7 +4,7 @@
   import { fade, fly } from "svelte/transition"
   import { tick } from "svelte"
 
-  let active = true
+  let active = false
   let value = ""
   let replace = ""
   let input

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -16,8 +16,8 @@
   $: searchItems(value, replace)
   $: if (active) focusInput()
   $: if (value || replace) message = ""
-  $: occurances = itemMatches.reduce((p, c) => p + c.contentMatches.length, 0)
-  $: occurancesString = `${occurances} occurance${occurances > 1 ? "s" : ""} in ${itemMatches.length} item${itemMatches.length > 1 ? "s" : ""}`
+  $: occurrences = itemMatches.reduce((p, c) => p + c.contentMatches.length, 0)
+  $: occurrencesString = `${occurrences} occurance${occurrences > 1 ? "s" : ""} in ${itemMatches.length} item${itemMatches.length > 1 ? "s" : ""}`
 
   function searchItems() {
     if (!active) return
@@ -71,7 +71,7 @@
       updateItem(item)
     })
 
-    message = `Replaced ${occurancesString}`
+    message = `Replaced ${occurrencesString}`
 
     searchItems()
   }
@@ -166,7 +166,7 @@
     <div class="matches">
       {#if itemMatches.length}
         <div class="text-italic text-dark mb-1/8">
-          Found {occurancesString}
+          Found {occurrencesString}
         </div>
       {/if}
 

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -1,0 +1,163 @@
+<script>
+  import { items } from "../../stores/editor"
+  import { getItemById, replaceBetween, setCurrentItemById } from "../../utils/editor"
+  import { fade, fly } from "svelte/transition"
+  import { tick } from "svelte"
+
+  let active = true
+  let value = ""
+  let input
+  let itemMatches = []
+  let selected = 0
+
+  $: searchItems(value)
+  $: if (active) focusInput()
+
+  function searchItems() {
+    if (!value) {
+      itemMatches = []
+      return
+    }
+
+    const filteredItems = $items.filter(i =>
+      i.type == "item" &&
+      i.content.indexOf(value) != -1)
+
+    const regex = new RegExp(value, 'g');
+
+    itemMatches = filteredItems.map(i => {
+      const contentMatches = []
+
+      let match = null
+      while ((match = regex.exec(i.content)) != null) {
+        const index = match.index
+        contentMatches.push({
+          index,
+          truncateStart: index > 10,
+          truncateEnd: index + value.length < i.content.length,
+          string: i.content.substring(
+            Math.max(0, index - 10),
+            Math.min(index + value.length + 20, i.content.length)
+          )
+        })
+      }
+
+      return {
+        id: i.id,
+        name: i.name,
+        parent: i.parent,
+        order: i.name.length - value.length,
+        contentMatches,
+      }
+    })
+
+    selected = 0
+  }
+
+  function highlightString(string) {
+    const index = string.indexOf(value)
+    const subString = string.substring(index, index + value.length)
+    return replaceBetween(string, `<mark>${ subString }</mark>`, index, index + value.length)
+  }
+
+  function getParentsString(id) {
+    if (!id) return ""
+
+    const itemNames = []
+
+    while (id) {
+      const parent = getItemById(id)
+      itemNames.push(parent.name)
+
+      id = parent.parent
+    }
+
+    return itemNames.reverse().join(" > ")
+  }
+
+  function selectItem(id) {
+    setCurrentItemById(id)
+  }
+
+  function setSelected(add) {
+    selected = selected + add
+    if (selected > itemMatches.length - 1 || selected > itemMatches.length - 1) selected = 0
+    else if (selected < 0) selected = itemMatches.length - 1
+  }
+
+  function keydown(event) {
+    if (input != document.activeElement) return
+
+    if (event.ctrlKey && event.shiftKey && event.keyCode == 70) { // F key
+      event.preventDefault()
+      active = !active
+      if (active) focusInput()
+    }
+
+    if (!active) return
+
+    if (selected && event.keyCode == 13) { // Enter key
+      selectItem(itemMatches[selected].id)
+    }
+
+    if (event.keyCode == 40) { // Down array
+      event.preventDefault()
+      setSelected(1)
+    }
+
+    if (event.keyCode == 38) { // Up array
+      event.preventDefault()
+      setSelected(-1)
+    }
+  }
+
+  async function focusInput() {
+    await tick()
+    input.focus()
+  }
+</script>
+
+<svelte:window on:keydown={keydown} on:keydown={event => { if (event.key === "Escape") active = false }} />
+
+{#if !active}
+  <button class="form-input bg-darker text-dark cursor-pointer text-left" on:click={() => active = true}>
+    <em>Find/Replace in all... (Ctrl+Shift+F)</em>
+  </button>
+{/if}
+
+{#if active}
+  <div class="flex mt-1/4">
+    <input type="text" class="form-input bg-darker" placeholder="Find in all files..." bind:value bind:this={input} />
+    <button class="button button--secondary button--square button--small ml-1/16">Find</button>
+  </div>
+
+  <em class="block mt-1/16 text-dark text-small">Note: Replace can not be undone</em>
+
+  {#if value}
+    <div class="matches">
+      {#each itemMatches as item, i}
+        <div class="matches__item" class:matches__item--active={selected == i} on:click={() => selectItem(item.id)}>
+          {item.name}
+
+          {#if item.parent}
+            <small class="text-dark">{getParentsString(item.parent)}</small>
+          {/if}
+
+          <div class="text-dark text-small">
+            <span class="text-white">Matches: {item.contentMatches.length}</span>
+
+            {#each item.contentMatches as match}
+              <div>
+                - {match.truncateStart ? "..." : ""}{@html highlightString(match.string)}{match.truncateEnd ? "..." : ""}
+              </div>
+            {/each}
+          </div>
+        </div>
+      {/each}
+
+      {#if !itemMatches.length}
+        <em class="text-dark pl-1/4">No matches found</em>
+      {/if}
+    </div>
+  {/if}
+{/if}

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -17,7 +17,7 @@
   $: if (active) focusInput()
   $: if (value || replace) message = ""
   $: occurrences = itemMatches.reduce((p, c) => p + c.contentMatches.length, 0)
-  $: occurrencesString = `${ occurrences } occurance${ occurrences > 1 ? "s" : "" } in ${ itemMatches.length } item${ itemMatches.length > 1 ? "s" : "" }`
+  $: occurrencesString = `${ occurrences } occurrence${ occurrences > 1 ? "s" : "" } in ${ itemMatches.length } item${ itemMatches.length > 1 ? "s" : "" }`
 
   function searchItems() {
     if (!active) return

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -30,7 +30,7 @@
       i.type == "item" &&
       i.content.indexOf(value) != -1)
 
-    const regex = new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), "g")
+    const regex = new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")
 
     itemMatches = filteredItems.map(i => {
       const contentMatches = []

--- a/app/javascript/src/components/editor/FindReplaceAll.svelte
+++ b/app/javascript/src/components/editor/FindReplaceAll.svelte
@@ -17,7 +17,7 @@
   $: if (active) focusInput()
   $: if (value || replace) message = ""
   $: occurrences = itemMatches.reduce((p, c) => p + c.contentMatches.length, 0)
-  $: occurrencesString = `${occurrences} occurance${occurrences > 1 ? "s" : ""} in ${itemMatches.length} item${itemMatches.length > 1 ? "s" : ""}`
+  $: occurrencesString = `${ occurrences } occurance${ occurrences > 1 ? "s" : "" } in ${ itemMatches.length } item${ itemMatches.length > 1 ? "s" : "" }`
 
   function searchItems() {
     if (!active) return
@@ -30,7 +30,7 @@
       i.type == "item" &&
       i.content.indexOf(value) != -1)
 
-    const regex = new RegExp(value, 'g');
+    const regex = new RegExp(value, "g")
 
     itemMatches = filteredItems.map(i => {
       const contentMatches = []
@@ -54,7 +54,7 @@
         name: i.name,
         parent: i.parent,
         order: i.name.length - value.length,
-        contentMatches,
+        contentMatches
       }
     })
 
@@ -71,7 +71,7 @@
       updateItem(item)
     })
 
-    message = `Replaced ${occurrencesString}`
+    message = `Replaced ${ occurrencesString }`
 
     searchItems()
   }

--- a/app/javascript/src/components/editor/ItemFinder.svelte
+++ b/app/javascript/src/components/editor/ItemFinder.svelte
@@ -73,12 +73,9 @@
 
     if (!active) return
 
-    if (event.keyCode == 13) {
-      selectItem(matches[selected].id)
-    }
-
-    if (event.keyCode == 40) setSelected(1)
-    if (event.keyCode == 38) setSelected(-1)
+    if (event.keyCode == 13) selectItem(matches[selected].id) // Enter key
+    if (event.keyCode == 40) setSelected(1) // Down key
+    if (event.keyCode == 38) setSelected(-1) // Up key
   }
 
   async function focusInput() {
@@ -99,7 +96,7 @@
       <input type="text" class="form-input form-input--large bg-darker" placeholder="Find files by name..." bind:value bind:this={input} />
 
       {#if value}
-        <div class="matches">
+        <div class="matches matches--dropdown">
           {#each sortedMatches as match, i}
             <div class="matches__item" class:matches__item--active={selected == i} on:click={() => selectItem(match.id)}>
               {@html highlightString(match.name, match.from)}

--- a/app/javascript/src/components/editor/ProjectsDropdown.svelte
+++ b/app/javascript/src/components/editor/ProjectsDropdown.svelte
@@ -45,6 +45,8 @@
         $items = JSON.parse(parsedData.content) || []
       })
       .catch(error => {
+        $items = []
+        $currentItem = {}
         console.error(error)
         alert(`Something went wrong while loading, please try again. ${ error }`)
       })


### PR DESCRIPTION
This PR adds Search/replace all to the Editor. This works by searching the content of all items and saving the found items index to an array. These indexes are only used to highlight the occurrences shown in the UI. When actually replacing the values we loop over all items that have occurrences and `.replaceAll` the value with the replacement.

Found items can be opened by clicking them or by using arrow key up and down and pressing enter while focusing either the search or the replace inputs. Pressing enter does not automatically submit the replace form, both to allow for opening of items with enter and to prevent accidentally submitting.

The inputs are hidden by default but can be opened with ctrl+shift+f, at which point you're automatically focused on the search input.

## Initial state
![image](https://user-images.githubusercontent.com/12848235/213818273-fb63c34c-24fd-4cc0-9f5c-c4e63802a3a3.png)

## Active state
![image](https://user-images.githubusercontent.com/12848235/213818296-942bf88c-7d16-4392-9e52-6e6f9a637b0c.png)

## Found single
![image](https://user-images.githubusercontent.com/12848235/213818318-237c495d-0b28-4eef-b474-e214e374749c.png)

## Found multiple, with replace
![image](https://user-images.githubusercontent.com/12848235/213821370-62c086fb-7bf8-4099-bb40-5b40ca942af0.png)
